### PR TITLE
feat: allow wrapper length to be configured

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const Script = require('./lib/script')
 
-module.exports = function (path) {
-  return new Script(path)
+module.exports = function (path, wrapperLength) {
+  return new Script(path, wrapperLength)
 }

--- a/lib/script.js
+++ b/lib/script.js
@@ -4,16 +4,17 @@ const CovBranch = require('./branch')
 const CovLine = require('./line')
 const CovFunction = require('./function')
 
-// Node.js injects a header when executing a script.
-const cjsHeader = require('module').wrapper[0]
+// Injected when Node.js is loading script into isolate.
+// see: https://github.com/nodejs/node/pull/21573.
+const cjsWrapperLength = require('module').wrapper[0].length
 
 module.exports = class CovScript {
-  constructor (scriptPath) {
+  constructor (scriptPath, wrapperLength) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
-    const { path, isESM } = parsePath(scriptPath)
+    const path = parsePath(scriptPath)
     const source = fs.readFileSync(path, 'utf8')
     this.path = path
-    this.header = isESM ? '' : cjsHeader
+    this.wrapperLength = wrapperLength === undefined ? cjsWrapperLength : wrapperLength
     this.lines = []
     this.branches = []
     this.functions = []
@@ -31,8 +32,8 @@ module.exports = class CovScript {
   applyCoverage (blocks) {
     blocks.forEach(block => {
       block.ranges.forEach(range => {
-        const startCol = Math.max(0, range.startOffset - this.header.length)
-        const endCol = Math.min(this.eof, range.endOffset - this.header.length)
+        const startCol = Math.max(0, range.startOffset - this.wrapperLength)
+        const endCol = Math.min(this.eof, range.endOffset - this.wrapperLength)
         const lines = this.lines.filter(line => {
           return startCol <= line.endCol && endCol >= line.startCol
         })
@@ -118,8 +119,5 @@ module.exports = class CovScript {
 }
 
 function parsePath (scriptPath) {
-  return {
-    path: scriptPath.replace('file://', ''),
-    isESM: scriptPath.indexOf('file://') !== -1
-  }
+  return scriptPath.replace('file://', '')
 }

--- a/test/script.js
+++ b/test/script.js
@@ -15,15 +15,16 @@ describe('Script', () => {
         require.resolve('./fixtures/scripts/functions.js')
       )
       script.lines.length.should.equal(49)
-      script.header.length.should.equal(62) // common-js header.
+      script.wrapperLength.should.equal(62) // common-js header.
     })
 
     it('handles ESM style paths', () => {
       const script = new Script(
-        `file://${require.resolve('./fixtures/scripts/functions.js')}`
+        `file://${require.resolve('./fixtures/scripts/functions.js')}`,
+        0
       )
       script.lines.length.should.equal(49)
-      script.header.length.should.equal(0) // ESM header.
+      script.wrapperLength.should.equal(0) // ESM header.
     })
   })
 


### PR DESCRIPTION
BREAKING CHANGE: we no longer attempt to detect ESM modules, rather the consumer sets a wrapper length