### PR TITLE
fix: windows has \r\n line separator

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -8,6 +8,8 @@ const CovFunction = require('./function')
 // see: https://github.com/nodejs/node/pull/21573.
 const cjsWrapperLength = require('module').wrapper[0].length
 
+const isWindows = process.platform === 'win32'
+
 module.exports = class CovScript {
   constructor (scriptPath, wrapperLength) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
@@ -23,10 +25,11 @@ module.exports = class CovScript {
   }
   _buildLines (source, lines) {
     let position = 0
-    source.split('\n').forEach((lineStr, i) => {
+    const separator = isWindows ? '\r\n' : '\n'
+    source.split(separator).forEach((lineStr, i) => {
       this.eof = position + lineStr.length
       lines.push(new CovLine(i + 1, position, this.eof))
-      position += lineStr.length + 1 // also add the \n.
+      position += lineStr.length + separator.length
     })
   }
   applyCoverage (blocks) {


### PR DESCRIPTION
Windows has a `\r\n` line separator, which was causing off by one errors in coverage.