### PR TITLE
feat: Node 11 no longer wraps scripts by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "10.10"
+  - "11"
 after_success: npm run coverage

--- a/lib/script.js
+++ b/lib/script.js
@@ -4,11 +4,12 @@ const CovBranch = require('./branch')
 const CovLine = require('./line')
 const CovFunction = require('./function')
 
-// Injected when Node.js is loading script into isolate.
-// see: https://github.com/nodejs/node/pull/21573.
-const cjsWrapperLength = require('module').wrapper[0].length
-
 const isWindows = process.platform === 'win32'
+const isNode10 = !!process.version.match(/^v10/)
+
+// Injected when Node.js is loading script into isolate pre Node 11.
+// see: https://github.com/nodejs/node/pull/21573.
+const cjsWrapperLength = isNode10 ? require('module').wrapper[0].length : 0
 
 module.exports = class CovScript {
   constructor (scriptPath, wrapperLength) {
@@ -17,19 +18,22 @@ module.exports = class CovScript {
     const source = fs.readFileSync(path, 'utf8')
     this.path = path
     this.wrapperLength = wrapperLength === undefined ? cjsWrapperLength : wrapperLength
-    this.wrapperLength -= shebangLength(source)
+    const shebangLength = getShebangLength(source)
+    this.wrapperLength -= shebangLength
     this.lines = []
     this.branches = []
     this.functions = []
     this.eof = -1
-    this._buildLines(source, this.lines)
+    this._buildLines(source, this.lines, shebangLength)
   }
-  _buildLines (source, lines) {
+  _buildLines (source, lines, shebangLength) {
     let position = 0
     const separator = isWindows ? '\r\n' : '\n'
-    source.split(separator).forEach((lineStr, i) => {
+    ;(source.trim()).split(separator).forEach((lineStr, i) => {
       this.eof = position + lineStr.length
-      lines.push(new CovLine(i + 1, position, this.eof))
+      const line = new CovLine(i + 1, position, this.eof)
+      if (i === 0 && shebangLength !== 0) line.count = 1
+      lines.push(line)
       position += lineStr.length + separator.length
     })
   }
@@ -135,7 +139,7 @@ module.exports = class CovScript {
   }
 }
 
-function shebangLength (source) {
+function getShebangLength (source) {
   if (source.indexOf('#!') === 0) {
     const match = source.match(/(?<shebang>#!.*)/)
     if (match) {

--- a/tap-snapshots/test-script.js-TAP.test.js
+++ b/tap-snapshots/test-script.js-TAP.test.js
@@ -82,9 +82,7 @@ exports[`test/script.js TAP > undefined 1`] = `
         end: { line: 30, column: 15 } },
      '30':
       { start: { line: 31, column: 0 },
-        end: { line: 31, column: 10 } },
-     '31':
-      { start: { line: 32, column: 0 }, end: { line: 32, column: 0 } } },
+        end: { line: 31, column: 10 } } },
   s:
    { '0': 1,
      '1': 1,
@@ -97,8 +95,8 @@ exports[`test/script.js TAP > undefined 1`] = `
      '8': 1,
      '9': 1,
      '10': 1,
-     '11': 0,
-     '12': 0,
+     '11': 1,
+     '12': 1,
      '13': 1,
      '14': 1,
      '15': 1,
@@ -108,84 +106,76 @@ exports[`test/script.js TAP > undefined 1`] = `
      '19': 1,
      '20': 1,
      '21': 1,
-     '22': 0,
-     '23': 0,
+     '22': 1,
+     '23': 1,
      '24': 1,
      '25': 1,
      '26': 1,
      '27': 1,
      '28': 1,
      '29': 1,
-     '30': 1,
-     '31': 1 },
+     '30': 1 },
   branchMap:
    { '0':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 1, column: 0 }, end: { line: 32, column: 0 } },
+         { start: { line: 1, column: 0 }, end: { line: 31, column: 10 } },
         locations:
-         [ { start: { line: 1, column: 0 }, end: { line: 32, column: 0 } } ] },
+         [ { start: { line: 1, column: 0 }, end: { line: 31, column: 10 } } ] },
      '1':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 1, column: 0 }, end: { line: 32, column: 0 } },
+         { start: { line: 1, column: 1 }, end: { line: 31, column: 10 } },
         locations:
-         [ { start: { line: 1, column: 0 }, end: { line: 32, column: 0 } } ] },
+         [ { start: { line: 1, column: 1 }, end: { line: 31, column: 10 } } ] },
      '2':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 2, column: 13 }, end: { line: 2, column: 18 } },
+         { start: { line: 5, column: 23 }, end: { line: 5, column: 28 } },
         locations:
-         [ { start: { line: 2, column: 13 }, end: { line: 2, column: 18 } } ] },
+         [ { start: { line: 5, column: 23 }, end: { line: 5, column: 28 } } ] },
      '3':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 5, column: 18 }, end: { line: 5, column: 25 } },
+         { start: { line: 8, column: 22 }, end: { line: 8, column: 29 } },
         locations:
-         [ { start: { line: 5, column: 18 }, end: { line: 5, column: 25 } } ] },
+         [ { start: { line: 8, column: 22 }, end: { line: 8, column: 29 } } ] },
      '4':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 8, column: 26 }, end: { line: 8, column: 31 } },
+         { start: { line: 14, column: 8 }, end: { line: 15, column: 4 } },
         locations:
-         [ { start: { line: 8, column: 26 }, end: { line: 8, column: 31 } } ] },
+         [ { start: { line: 14, column: 8 }, end: { line: 15, column: 4 } } ] },
      '5':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 11, column: 11 },
-           end: { line: 13, column: 1 } },
+         { start: { line: 18, column: 3 },
+           end: { line: 18, column: 21 } },
         locations:
-         [ { start: { line: 11, column: 11 },
-             end: { line: 13, column: 1 } } ] },
+         [ { start: { line: 18, column: 3 },
+             end: { line: 18, column: 21 } } ] },
      '6':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 31, column: 5 },
-           end: { line: 31, column: 10 } },
+         { start: { line: 22, column: 8 }, end: { line: 30, column: 8 } },
         locations:
-         [ { start: { line: 31, column: 5 },
-             end: { line: 31, column: 10 } } ] },
+         [ { start: { line: 22, column: 8 }, end: { line: 30, column: 8 } } ] },
      '7':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 19, column: 0 }, end: { line: 25, column: 1 } },
+         { start: { line: 29, column: 31 },
+           end: { line: 30, column: 6 } },
         locations:
-         [ { start: { line: 19, column: 0 }, end: { line: 25, column: 1 } } ] },
-     '8':
-      { type: 'branch',
-        line: undefined,
-        loc:
-         { start: { line: 22, column: 9 }, end: { line: 24, column: 3 } },
-        locations:
-         [ { start: { line: 22, column: 9 }, end: { line: 24, column: 3 } } ] } },
+         [ { start: { line: 29, column: 31 },
+             end: { line: 30, column: 6 } } ] } },
   b:
    { '0': [ 1 ],
      '1': [ 1 ],
@@ -193,17 +183,16 @@ exports[`test/script.js TAP > undefined 1`] = `
      '3': [ 0 ],
      '4': [ 0 ],
      '5': [ 0 ],
-     '6': [ 0 ],
-     '7': [ 1 ],
-     '8': [ 0 ] },
+     '6': [ 1 ],
+     '7': [ 0 ] },
   fnMap:
    { '0':
       { name: 'e',
         decl:
-         { start: { line: 19, column: 0 }, end: { line: 25, column: 1 } },
+         { start: { line: 22, column: 8 }, end: { line: 30, column: 8 } },
         loc:
-         { start: { line: 19, column: 0 }, end: { line: 25, column: 1 } },
-        line: 19 } },
+         { start: { line: 22, column: 8 }, end: { line: 30, column: 8 } },
+        line: 22 } },
   f: { '0': 1 } }
 `
 
@@ -326,19 +315,17 @@ exports[`test/script.js TAP > undefined 2`] = `
       { start: { line: 47, column: 0 },
         end: { line: 47, column: 19 } },
      '47':
-      { start: { line: 48, column: 0 }, end: { line: 48, column: 9 } },
-     '48':
-      { start: { line: 49, column: 0 }, end: { line: 49, column: 0 } } },
+      { start: { line: 48, column: 0 }, end: { line: 48, column: 9 } } },
   s:
    { '0': 1,
-     '1': 0,
-     '2': 0,
-     '3': 0,
+     '1': 1,
+     '2': 1,
+     '3': 1,
      '4': 0,
      '5': 0,
-     '6': 1,
-     '7': 1,
-     '8': 1,
+     '6': 0,
+     '7': 0,
+     '8': 0,
      '9': 1,
      '10': 1,
      '11': 1,
@@ -349,25 +336,25 @@ exports[`test/script.js TAP > undefined 2`] = `
      '16': 1,
      '17': 1,
      '18': 1,
-     '19': 2,
-     '20': 2,
-     '21': 2,
-     '22': 2,
+     '19': 1,
+     '20': 1,
+     '21': 1,
+     '22': 1,
      '23': 1,
      '24': 1,
      '25': 1,
      '26': 1,
      '27': 1,
      '28': 1,
-     '29': 0,
-     '30': 0,
+     '29': 1,
+     '30': 1,
      '31': 1,
-     '32': 0,
+     '32': 1,
      '33': 0,
-     '34': 1,
-     '35': 1,
+     '34': 0,
+     '35': 0,
      '36': 1,
-     '37': 1,
+     '37': 0,
      '38': 1,
      '39': 1,
      '40': 1,
@@ -377,84 +364,79 @@ exports[`test/script.js TAP > undefined 2`] = `
      '44': 1,
      '45': 1,
      '46': 1,
-     '47': 1,
-     '48': 1 },
+     '47': 1 },
   branchMap:
    { '0':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 1, column: 0 }, end: { line: 49, column: 0 } },
+         { start: { line: 1, column: 0 }, end: { line: 48, column: 9 } },
         locations:
-         [ { start: { line: 1, column: 0 }, end: { line: 49, column: 0 } } ] },
+         [ { start: { line: 1, column: 0 }, end: { line: 48, column: 9 } } ] },
      '1':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 1, column: 0 }, end: { line: 49, column: 0 } },
+         { start: { line: 1, column: 1 }, end: { line: 48, column: 9 } },
         locations:
-         [ { start: { line: 1, column: 0 }, end: { line: 49, column: 0 } } ] },
+         [ { start: { line: 1, column: 1 }, end: { line: 48, column: 9 } } ] },
      '2':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 9, column: 2 }, end: { line: 14, column: 3 } },
+         { start: { line: 11, column: 8 },
+           end: { line: 19, column: 13 } },
         locations:
-         [ { start: { line: 9, column: 2 }, end: { line: 14, column: 3 } } ] },
+         [ { start: { line: 11, column: 8 },
+             end: { line: 19, column: 13 } } ] },
      '3':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 10, column: 28 },
-           end: { line: 10, column: 37 } },
+         { start: { line: 13, column: 6 }, end: { line: 14, column: 1 } },
         locations:
-         [ { start: { line: 10, column: 28 },
-             end: { line: 10, column: 37 } } ] },
+         [ { start: { line: 13, column: 6 }, end: { line: 14, column: 1 } } ] },
      '4':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 12, column: 18 },
-           end: { line: 12, column: 23 } },
+         { start: { line: 18, column: 32 },
+           end: { line: 18, column: 37 } },
         locations:
-         [ { start: { line: 12, column: 18 },
-             end: { line: 12, column: 23 } } ] },
+         [ { start: { line: 18, column: 32 },
+             end: { line: 18, column: 37 } } ] },
      '5':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 13, column: 13 },
-           end: { line: 14, column: 2 } },
+         { start: { line: 19, column: 9 },
+           end: { line: 19, column: 12 } },
         locations:
-         [ { start: { line: 13, column: 13 },
-             end: { line: 14, column: 2 } } ] },
+         [ { start: { line: 19, column: 9 },
+             end: { line: 19, column: 12 } } ] },
      '6':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 19, column: 10 },
-           end: { line: 23, column: 1 } },
+         { start: { line: 27, column: 1 }, end: { line: 28, column: 1 } },
         locations:
-         [ { start: { line: 19, column: 10 },
-             end: { line: 23, column: 1 } } ] },
+         [ { start: { line: 27, column: 1 }, end: { line: 28, column: 1 } } ] },
      '7':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 39, column: 16 },
-           end: { line: 41, column: 5 } },
+         { start: { line: 43, column: 15 },
+           end: { line: 44, column: 5 } },
         locations:
-         [ { start: { line: 39, column: 16 },
-             end: { line: 41, column: 5 } } ] },
+         [ { start: { line: 43, column: 15 },
+             end: { line: 44, column: 5 } } ] },
      '8':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 42, column: 10 },
-           end: { line: 44, column: 5 } },
+         { start: { line: 47, column: 5 }, end: { line: 48, column: 9 } },
         locations:
-         [ { start: { line: 42, column: 10 },
-             end: { line: 44, column: 5 } } ] } },
+         [ { start: { line: 47, column: 5 }, end: { line: 48, column: 9 } } ] } },
   b:
    { '0': [ 1 ],
      '1': [ 1 ],
@@ -469,60 +451,62 @@ exports[`test/script.js TAP > undefined 2`] = `
    { '0':
       { name: 'a',
         decl:
-         { start: { line: 2, column: 0 }, end: { line: 6, column: 1 } },
+         { start: { line: 4, column: 30 },
+           end: { line: 10, column: 10 } },
         loc:
-         { start: { line: 2, column: 0 }, end: { line: 6, column: 1 } },
-        line: 2 },
+         { start: { line: 4, column: 30 },
+           end: { line: 10, column: 10 } },
+        line: 4 },
      '1':
       { name: 'b',
         decl:
-         { start: { line: 9, column: 2 }, end: { line: 14, column: 3 } },
+         { start: { line: 11, column: 8 },
+           end: { line: 19, column: 13 } },
         loc:
-         { start: { line: 9, column: 2 }, end: { line: 14, column: 3 } },
-        line: 9 },
+         { start: { line: 11, column: 8 },
+           end: { line: 19, column: 13 } },
+        line: 11 },
      '2':
       { name: 'c',
         decl:
-         { start: { line: 19, column: 10 },
-           end: { line: 23, column: 1 } },
+         { start: { line: 27, column: 1 }, end: { line: 28, column: 1 } },
         loc:
-         { start: { line: 19, column: 10 },
-           end: { line: 23, column: 1 } },
-        line: 19 },
+         { start: { line: 27, column: 1 }, end: { line: 28, column: 1 } },
+        line: 27 },
      '3':
       { name: 'Foo',
         decl:
-         { start: { line: 29, column: 14 },
-           end: { line: 31, column: 3 } },
+         { start: { line: 33, column: 21 },
+           end: { line: 37, column: 15 } },
         loc:
-         { start: { line: 29, column: 14 },
-           end: { line: 31, column: 3 } },
-        line: 29 },
+         { start: { line: 33, column: 21 },
+           end: { line: 37, column: 15 } },
+        line: 33 },
      '4':
       { name: 'hello',
         decl:
-         { start: { line: 32, column: 8 }, end: { line: 34, column: 3 } },
+         { start: { line: 37, column: 24 },
+           end: { line: 39, column: 1 } },
         loc:
-         { start: { line: 32, column: 8 }, end: { line: 34, column: 3 } },
-        line: 32 },
+         { start: { line: 37, column: 24 },
+           end: { line: 39, column: 1 } },
+        line: 37 },
      '5':
       { name: 'Bar',
         decl:
-         { start: { line: 39, column: 16 },
-           end: { line: 41, column: 5 } },
+         { start: { line: 43, column: 15 },
+           end: { line: 44, column: 5 } },
         loc:
-         { start: { line: 39, column: 16 },
-           end: { line: 41, column: 5 } },
-        line: 39 },
+         { start: { line: 43, column: 15 },
+           end: { line: 44, column: 5 } },
+        line: 43 },
      '6':
       { name: 'hello',
         decl:
-         { start: { line: 42, column: 10 },
-           end: { line: 44, column: 5 } },
+         { start: { line: 47, column: 5 }, end: { line: 48, column: 9 } },
         loc:
-         { start: { line: 42, column: 10 },
-           end: { line: 44, column: 5 } },
-        line: 42 } },
+         { start: { line: 47, column: 5 }, end: { line: 48, column: 9 } },
+        line: 47 } },
   f: { '0': 0, '1': 1, '2': 2, '3': 0, '4': 0, '5': 1, '6': 1 } }
 `
 
@@ -552,31 +536,17 @@ exports[`test/script.js TAP > undefined 3`] = `
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 1, column: 0 }, end: { line: 8, column: 7 } },
+         { start: { line: 1, column: 19 }, end: { line: 8, column: 7 } },
         locations:
-         [ { start: { line: 1, column: 0 }, end: { line: 8, column: 7 } } ] },
+         [ { start: { line: 1, column: 19 }, end: { line: 8, column: 7 } } ] },
      '1':
       { type: 'branch',
         line: undefined,
         loc:
-         { start: { line: 1, column: 0 }, end: { line: 8, column: 7 } },
+         { start: { line: 2, column: 0 }, end: { line: 8, column: 7 } },
         locations:
-         [ { start: { line: 1, column: 0 }, end: { line: 8, column: 7 } } ] },
-     '2':
-      { type: 'branch',
-        line: undefined,
-        loc:
-         { start: { line: 4, column: 0 }, end: { line: 6, column: 1 } },
-        locations:
-         [ { start: { line: 4, column: 0 }, end: { line: 6, column: 1 } } ] } },
-  b: { '0': [ 1 ], '1': [ 1 ], '2': [ 1 ] },
-  fnMap:
-   { '0':
-      { name: 'hello',
-        decl:
-         { start: { line: 4, column: 0 }, end: { line: 6, column: 1 } },
-        loc:
-         { start: { line: 4, column: 0 }, end: { line: 6, column: 1 } },
-        line: 4 } },
-  f: { '0': 1 } }
+         [ { start: { line: 2, column: 0 }, end: { line: 8, column: 7 } } ] } },
+  b: { '0': [ 1 ], '1': [ 1 ] },
+  fnMap: {},
+  f: {} }
 `

--- a/test/script.js
+++ b/test/script.js
@@ -14,8 +14,8 @@ describe('Script', () => {
       const script = new Script(
         require.resolve('./fixtures/scripts/functions.js')
       )
-      script.lines.length.should.equal(49)
-      script.wrapperLength.should.equal(62) // common-js header.
+      script.lines.length.should.equal(48)
+      script.wrapperLength.should.equal(0) // common-js header.
     })
 
     it('handles ESM style paths', () => {
@@ -23,7 +23,7 @@ describe('Script', () => {
         `file://${require.resolve('./fixtures/scripts/functions.js')}`,
         0
       )
-      script.lines.length.should.equal(49)
+      script.lines.length.should.equal(48)
       script.wrapperLength.should.equal(0) // ESM header.
     })
   })


### PR DESCRIPTION
By default in Node 11+ there is no longer a wrapper around scripts, see:

https://github.com/nodejs/node/pull/21573