### PR TITLE
fix: column could be < 1 when wrapper taken into account

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -101,7 +101,7 @@ function originalEndPositionFor (sourceMap, line, column) {
   const beforeEndMapping = originalPositionTryBoth(
     sourceMap,
     line,
-    column - 1
+    Math.max(column - 1, 1)
   )
 
   if (beforeEndMapping.source === null) {


### PR DESCRIPTION
In Node.js 10, it was possible for the column position to be less than 1 after subtracting the wrapper; this problem should go away once https://github.com/nodejs/node/pull/27124 is released.