### PR TITLE
chore: test with Node.js v12 instead of no longer maintained v11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "11"
+  - "12"
 after_success: npm run coverage


### PR DESCRIPTION
11.x is End-of-Life starting at the 2019-06-01. https://github.com/nodejs/Release/blob/c7be2c8908acd876a4393ff90c62100942ebba1b/README.md#end-of-life-releases