### PR TITLE
fix: logic for handling sourceRoot does not take into account process.cwd()

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -1,4 +1,4 @@
-const { relativeTo } = require('./pathutils')
+const { isAbsolute, relativeTo } = require('./pathutils')
 const assert = require('assert')
 const convertSourceMap = require('convert-source-map')
 const { dirname, join } = require('path')
@@ -40,7 +40,9 @@ module.exports = class V8ToIstanbul {
         console.warn('v8-to-istanbul: source-mappings from one to many files not yet supported')
         this.source = new CovSource(rawSource, this.wrapperLength)
       } else {
-        if (rawSourceMap.sourcemap.sourceRoot) {
+        if (rawSourceMap.sourcemap.sourceRoot && isAbsolute(rawSourceMap.sourcemap.sourceRoot)) {
+          // TODO: we should also make source-root work with relative paths, but this needs
+          // to be combined with the relativeTo logic which takes into account process.cwd().
           this.path = join(rawSourceMap.sourcemap.sourceRoot, rawSourceMap.sourcemap.sources[0])
         } else {
           this.path = relativeTo(rawSourceMap.sourcemap.sources[0], this.path)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
+    "fix": "standard --fix",
     "snapshot": "TAP_SNAPSHOT=1 tap test/*.js",
     "test": "c8 --reporter=html --reporter=text tap --no-coverage --no-esm test/*.js",
     "posttest": "standard",


### PR DESCRIPTION
currently the logic for handling sourceRoot does not attempt to take into account `process.cwd()`, this means it can't work for relative paths in most environments.