### PR TITLE
fix: Node >10.16.0 now uses new module wrap API

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -8,11 +8,11 @@ const CovSource = require('./source')
 const { readFileSync } = require('fs')
 const { SourceMapConsumer } = require('source-map')
 
-const isNode10 = !!process.version.match(/^v10/)
+const isOlderNode10 = /^v10\.[0-5]/u.test(process.version)
 
-// Injected when Node.js is loading script into isolate pre Node 11.
+// Injected when Node.js is loading script into isolate pre Node 10.16.x.
 // see: https://github.com/nodejs/node/pull/21573.
-const cjsWrapperLength = isNode10 ? require('module').wrapper[0].length : 0
+const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
 
 module.exports = class V8ToIstanbul {
   constructor (scriptPath, wrapperLength, sources) {


### PR DESCRIPTION
fixes: https://github.com/bcoe/c8/issues/111