### PR TITLE
chore: load a source file asynchronously

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -5,7 +5,7 @@ const { dirname, join } = require('path')
 const CovBranch = require('./branch')
 const CovFunction = require('./function')
 const CovSource = require('./source')
-const { readFileSync } = require('fs')
+const { readFile } = require('fs').promises
 const { SourceMapConsumer } = require('source-map')
 
 const isOlderNode10 = /^v10\.(([0-9]\.)|(1[0-5]\.))/u.test(process.version)
@@ -28,7 +28,7 @@ module.exports = class V8ToIstanbul {
     this.sourceTranspiled = undefined
   }
   async load () {
-    const rawSource = this.sources.source || readFileSync(this.path, 'utf8')
+    const rawSource = this.sources.source || await readFile(this.path, 'utf8')
     const rawSourceMap = this.sources.sourceMap ||
       // if we find a source-map (either inline, or a .map file) we load
       // both the transpiled and original source, both of which are used during
@@ -53,7 +53,7 @@ module.exports = class V8ToIstanbul {
         if (this.sources.originalSource) {
           originalRawSource = this.sources.originalSource
         } else {
-          originalRawSource = readFileSync(this.path, 'utf8')
+          originalRawSource = await readFile(this.path, 'utf8')
         }
 
         this.source = new CovSource(originalRawSource, this.wrapperLength)


### PR DESCRIPTION
As [`.load()` is already an async function](https://github.com/istanbuljs/v8-to-istanbul/blob/v3.2.3/lib/v8-to-istanbul.js#L30), we can use `fs.promises.readFile()` inside the method.
