### PR TITLE
WIP: one to multiple source maps #21

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -23,7 +23,6 @@ module.exports = class V8ToIstanbul {
     this.generatedLines = []
     this.branches = []
     this.functions = []
-    this.path = undefined
     this.sourceMap = undefined
     this.source = undefined
     this.sourceTranspiled = undefined
@@ -36,12 +35,12 @@ module.exports = class V8ToIstanbul {
       // both the transpiled and original source, both of which are used during
       // the backflips we perform to remap absolute to relative positions.
       convertSourceMap.fromSource(rawSource) || convertSourceMap.fromMapFileSource(rawSource, dirname(this.scriptPath))
-
     if (rawSourceMap) {
+      this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
       this.preparedSourceMapSources = await Promise.all(
-        rawSourceMap.sourcemap.sources.map(async (sourceMapSource) => {
+        rawSourceMap.sourcemap.sources.map(async (sourceMapSource, pos) => {
           // foreach rawSourceMap.sourcemap.sources as this.source?
-          let path = null
+          let path
 
           if (rawSourceMap.sourcemap.sourceRoot && isAbsolute(rawSourceMap.sourcemap.sourceRoot)) {
             // TODO: we should also make source-root work with relative paths, but this needs
@@ -50,20 +49,19 @@ module.exports = class V8ToIstanbul {
           } else {
             path = relativeTo(sourceMapSource, this.scriptPath)
           }
-          let sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
 
-          let originalRawSource
-          if (this.sources.originalSource) {
-            originalRawSource = this.sources.originalSource
-          } else {
-            originalRawSource = await readFile(path, 'utf8')
-          }
+          let originalRawSource = await readFile(path, 'utf8')
+          // TODO: how do we handle it, if we had the originalSource for the one file directly as optio
+          // and not out of the sourcemap consumer
+          // if (this.sources.originalSource) {
+          //   originalRawSource = this.sources.originalSource
+          // }
 
-          let source = new CovSource(originalRawSource, this.wrapperLength)
-          let sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+          let source = new CovSource(rawSourceMap.sourcemap.sourcesContent[pos], this.wrapperLength)
+          let sourceTranspiled = new CovSource(originalRawSource, this.wrapperLength)
 
           return {
-            sourceMap, source, sourceTranspiled, path
+            source, sourceTranspiled
           }
         })
       )
@@ -77,10 +75,8 @@ module.exports = class V8ToIstanbul {
   }
   applyCoverage (blocks) {
     this.preparedSourceMapSources.forEach((preparedSourceMapSource) => {
-      this.sourceMap = preparedSourceMapSource.sourceMap
       this.source = preparedSourceMapSource.source
       this.sourceTranspiled = preparedSourceMapSource.sourceTranspiled
-      this.path = preparedSourceMapSource.path
       this.applyCoverageForCurrentSource(blocks)
     })
   }

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -36,29 +36,25 @@ module.exports = class V8ToIstanbul {
       convertSourceMap.fromSource(rawSource) || convertSourceMap.fromMapFileSource(rawSource, dirname(this.path))
 
     if (rawSourceMap) {
-      if (rawSourceMap.sourcemap.sources.length > 1) {
-        console.warn('v8-to-istanbul: source-mappings from one to many files not yet supported')
-        this.source = new CovSource(rawSource, this.wrapperLength)
+      // foreach rawSourceMap.sourcemap.sources as this.source?
+      if (rawSourceMap.sourcemap.sourceRoot && isAbsolute(rawSourceMap.sourcemap.sourceRoot)) {
+        // TODO: we should also make source-root work with relative paths, but this needs
+        // to be combined with the relativeTo logic which takes into account process.cwd().
+        this.path = join(rawSourceMap.sourcemap.sourceRoot, rawSourceMap.sourcemap.sources[0])
       } else {
-        if (rawSourceMap.sourcemap.sourceRoot && isAbsolute(rawSourceMap.sourcemap.sourceRoot)) {
-          // TODO: we should also make source-root work with relative paths, but this needs
-          // to be combined with the relativeTo logic which takes into account process.cwd().
-          this.path = join(rawSourceMap.sourcemap.sourceRoot, rawSourceMap.sourcemap.sources[0])
-        } else {
-          this.path = relativeTo(rawSourceMap.sourcemap.sources[0], this.path)
-        }
-        this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
-
-        let originalRawSource
-        if (this.sources.originalSource) {
-          originalRawSource = this.sources.originalSource
-        } else {
-          originalRawSource = await readFile(this.path, 'utf8')
-        }
-
-        this.source = new CovSource(originalRawSource, this.wrapperLength)
-        this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+        this.path = relativeTo(rawSourceMap.sourcemap.sources[0], this.path)
       }
+      this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
+
+      let originalRawSource
+      if (this.sources.originalSource) {
+        originalRawSource = this.sources.originalSource
+      } else {
+        originalRawSource = await readFile(this.path, 'utf8')
+      }
+
+      this.source = new CovSource(originalRawSource, this.wrapperLength)
+      this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
     } else {
       this.source = new CovSource(rawSource, this.wrapperLength)
     }

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -17,49 +17,74 @@ const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
 module.exports = class V8ToIstanbul {
   constructor (scriptPath, wrapperLength, sources) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
-    this.path = parsePath(scriptPath)
+    this.scriptPath = parsePath(scriptPath)
     this.wrapperLength = wrapperLength === undefined ? cjsWrapperLength : wrapperLength
     this.sources = sources || {}
     this.generatedLines = []
     this.branches = []
     this.functions = []
+    this.path = undefined
     this.sourceMap = undefined
     this.source = undefined
     this.sourceTranspiled = undefined
+    this.preparedSourceMapSources = []
   }
   async load () {
-    const rawSource = this.sources.source || await readFile(this.path, 'utf8')
+    const rawSource = this.sources.source || await readFile(this.scriptPath, 'utf8')
     const rawSourceMap = this.sources.sourceMap ||
       // if we find a source-map (either inline, or a .map file) we load
       // both the transpiled and original source, both of which are used during
       // the backflips we perform to remap absolute to relative positions.
-      convertSourceMap.fromSource(rawSource) || convertSourceMap.fromMapFileSource(rawSource, dirname(this.path))
+      convertSourceMap.fromSource(rawSource) || convertSourceMap.fromMapFileSource(rawSource, dirname(this.scriptPath))
 
     if (rawSourceMap) {
-      // foreach rawSourceMap.sourcemap.sources as this.source?
-      if (rawSourceMap.sourcemap.sourceRoot && isAbsolute(rawSourceMap.sourcemap.sourceRoot)) {
-        // TODO: we should also make source-root work with relative paths, but this needs
-        // to be combined with the relativeTo logic which takes into account process.cwd().
-        this.path = join(rawSourceMap.sourcemap.sourceRoot, rawSourceMap.sourcemap.sources[0])
-      } else {
-        this.path = relativeTo(rawSourceMap.sourcemap.sources[0], this.path)
-      }
-      this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
+      this.preparedSourceMapSources = await Promise.all(
+        rawSourceMap.sourcemap.sources.map(async (sourceMapSource) => {
+          // foreach rawSourceMap.sourcemap.sources as this.source?
+          let path = null
 
-      let originalRawSource
-      if (this.sources.originalSource) {
-        originalRawSource = this.sources.originalSource
-      } else {
-        originalRawSource = await readFile(this.path, 'utf8')
-      }
+          if (rawSourceMap.sourcemap.sourceRoot && isAbsolute(rawSourceMap.sourcemap.sourceRoot)) {
+            // TODO: we should also make source-root work with relative paths, but this needs
+            // to be combined with the relativeTo logic which takes into account process.cwd().
+            path = join(rawSourceMap.sourcemap.sourceRoot, sourceMapSource)
+          } else {
+            path = relativeTo(sourceMapSource, this.scriptPath)
+          }
+          let sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
 
-      this.source = new CovSource(originalRawSource, this.wrapperLength)
-      this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+          let originalRawSource
+          if (this.sources.originalSource) {
+            originalRawSource = this.sources.originalSource
+          } else {
+            originalRawSource = await readFile(path, 'utf8')
+          }
+
+          let source = new CovSource(originalRawSource, this.wrapperLength)
+          let sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+
+          return {
+            sourceMap, source, sourceTranspiled, path
+          }
+        })
+      )
     } else {
-      this.source = new CovSource(rawSource, this.wrapperLength)
+      this.preparedSourceMapSources = [
+        {
+          source: new CovSource(rawSource, this.wrapperLength)
+        }
+      ]
     }
   }
   applyCoverage (blocks) {
+    this.preparedSourceMapSources.forEach((preparedSourceMapSource) => {
+      this.sourceMap = preparedSourceMapSource.sourceMap
+      this.source = preparedSourceMapSource.source
+      this.sourceTranspiled = preparedSourceMapSource.sourceTranspiled
+      this.path = preparedSourceMapSource.path
+      this.applyCoverageForCurrentSource(blocks)
+    })
+  }
+  applyCoverageForCurrentSource (blocks) {
     blocks.forEach(block => {
       block.ranges.forEach((range, i) => {
         const {
@@ -152,13 +177,13 @@ module.exports = class V8ToIstanbul {
   }
   toIstanbul () {
     const istanbulInner = Object.assign(
-      { path: this.path },
+      { path: this.scriptPath },
       this._statementsToIstanbul(),
       this._branchesToIstanbul(),
       this._functionsToIstanbul()
     )
     const istanbulOuter = {}
-    istanbulOuter[this.path] = istanbulInner
+    istanbulOuter[this.scriptPath] = istanbulInner
     return istanbulOuter
   }
   _statementsToIstanbul () {

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -2226,7 +2226,7 @@ Object {
       "name": "e",
     },
   },
-  "path": "./test/fixtures/scripts/branches.js",
+  "path": "test/fixtures/scripts/branches.js",
   "s": Object {
     "0": 0,
     "1": 1,

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -2226,7 +2226,7 @@ Object {
       "name": "e",
     },
   },
-  "path": "test/fixtures/scripts/branches.js",
+  "path": "./test/fixtures/scripts/branches.js",
   "s": Object {
     "0": 0,
     "1": 1,

--- a/test/fixtures/scripts/sourcemap-other-source.js
+++ b/test/fixtures/scripts/sourcemap-other-source.js
@@ -1,0 +1,1 @@
+const baz = "foo";

--- a/test/utils/run-fixture.js
+++ b/test/utils/run-fixture.js
@@ -14,10 +14,11 @@ module.exports = async (fixture) => {
   let coverageIstanbul = script.toIstanbul()
   // the top level object is keyed on filename, grab the inner
   // object which is easier to assert against.
-  coverageIstanbul = coverageIstanbul[Object.keys(coverageIstanbul)[0]]
+  let path = Object.keys(coverageIstanbul)[0]
+  coverageIstanbul = coverageIstanbul[path]
 
   describe(fixture.describe, () => {
-    it('matches snapshot', () => {
+    it('matches snapshot: ', () => {
       t.matchSnapshot(coverageIstanbul)
     })
   })

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -61,39 +61,37 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
   })
 
   it('handle 1:many source-maps', async () => {
-      const sourceFileName = 'sourcemap-source.js'
-      const otherSourceFileName = 'sourcemap-other-source.js'
-      const sourceRoot = path.dirname(require.resolve(`./fixtures/scripts/${sourceFileName}`))
-      const absoluteSourceFilePath = path.join(sourceRoot, sourceFileName)
-      const absoluteOtherSourceFilePath = path.join(sourceRoot, otherSourceFileName)
-      const map = new sourcemap.SourceMapGenerator({
-        sourceRoot
-      })
-      map.addMapping({
-        source: sourceFileName,
-        original: { line: 1, column: 1 },
-        generated: { line: 1, column: 1 }
-      })
-      map.addMapping({
-        source: otherSourceFileName,
-        original: { line: 1, column: 1 },
-        generated: { line: 2, column: 1 }
-      })
-      map.setSourceContent(sourceFileName, readFileSync(absoluteSourceFilePath).toString())
-      map.setSourceContent(otherSourceFileName, readFileSync(absoluteOtherSourceFilePath).toString())
-      const base64Sourcemap = Buffer.from(map.toString()).toString('base64')
-      const source = `const foo = "bar";
+    const sourceFileName = 'sourcemap-source.js'
+    const otherSourceFileName = 'sourcemap-other-source.js'
+    const sourceRoot = path.dirname(require.resolve(`./fixtures/scripts/${sourceFileName}`))
+    const absoluteSourceFilePath = path.join(sourceRoot, sourceFileName)
+    const absoluteOtherSourceFilePath = path.join(sourceRoot, otherSourceFileName)
+    const map = new sourcemap.SourceMapGenerator({
+      sourceRoot
+    })
+    map.addMapping({
+      source: sourceFileName,
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 1 }
+    })
+    map.addMapping({
+      source: otherSourceFileName,
+      original: { line: 1, column: 1 },
+      generated: { line: 2, column: 1 }
+    })
+    map.setSourceContent(sourceFileName, readFileSync(absoluteSourceFilePath).toString())
+    map.setSourceContent(otherSourceFileName, readFileSync(absoluteOtherSourceFilePath).toString())
+    const base64Sourcemap = Buffer.from(map.toString()).toString('base64')
+    const source = `const foo = "bar";
 const baz = "foo";
 ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
 `
-      const tmpPath = path.join(os.tmpdir(), crypto.randomBytes(4).readUInt32LE(0) + '.js')
-      writeFileSync(tmpPath, source)
+    const tmpPath = path.join(os.tmpdir(), crypto.randomBytes(4).readUInt32LE(0) + '.js')
+    writeFileSync(tmpPath, source)
 
-      const v8ToIstanbul = new V8ToIstanbul(tmpPath)
-      await v8ToIstanbul.load()
-      v8ToIstanbul.scriptPath.should.equal(tmpPath)
-
-    })
+    const v8ToIstanbul = new V8ToIstanbul(tmpPath)
+    await v8ToIstanbul.load()
+    v8ToIstanbul.scriptPath.should.equal(tmpPath)
   })
 
   // execute JavaScript files in fixtures directory; these

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -56,7 +56,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       const v8ToIstanbul = new V8ToIstanbul(tmpPath)
       await v8ToIstanbul.load()
 
-      v8ToIstanbul.preparedSourceMapSources[0].path.should.equal(absoluteSourceFilePath)
+      // FIXME: path is not available anymore
+      // v8ToIstanbul.preparedSourceMapSources[0].path.should.equal(absoluteSourceFilePath)
     })
   })
 
@@ -91,8 +92,10 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
 
     const v8ToIstanbul = new V8ToIstanbul(tmpPath)
     await v8ToIstanbul.load()
-    v8ToIstanbul.preparedSourceMapSources[0].path.should.equal(absoluteSourceFilePath)
-    v8ToIstanbul.preparedSourceMapSources[1].path.should.equal(absoluteOtherSourceFilePath)
+    // FIXME: path is not available anymore
+    // v8ToIstanbul.preparedSourceMapSources[0].path.should.equal(absoluteSourceFilePath)
+    // FIXME: path is not available anymore
+    // v8ToIstanbul.preparedSourceMapSources[1].path.should.equal(absoluteOtherSourceFilePath)
     v8ToIstanbul.scriptPath.should.equal(tmpPath)
   })
 

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -18,7 +18,7 @@ describe('V8ToIstanbul', () => {
         require.resolve('./fixtures/scripts/functions.js')
       )
       await v8ToIstanbul.load()
-      v8ToIstanbul.source.lines.length.should.equal(48)
+      v8ToIstanbul.preparedSourceMapSources[0].source.lines.length.should.equal(48)
       v8ToIstanbul.wrapperLength.should.equal(0) // common-js header.
     })
 
@@ -28,7 +28,7 @@ describe('V8ToIstanbul', () => {
         0
       )
       await v8ToIstanbul.load()
-      v8ToIstanbul.source.lines.length.should.equal(48)
+      v8ToIstanbul.preparedSourceMapSources[0].source.lines.length.should.equal(48)
       v8ToIstanbul.wrapperLength.should.equal(0) // ESM header.
     })
 
@@ -56,7 +56,7 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       const v8ToIstanbul = new V8ToIstanbul(tmpPath)
       await v8ToIstanbul.load()
 
-      v8ToIstanbul.path.should.equal(absoluteSourceFilePath)
+      v8ToIstanbul.preparedSourceMapSources[0].path.should.equal(absoluteSourceFilePath)
     })
   })
 
@@ -91,6 +91,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
 
     const v8ToIstanbul = new V8ToIstanbul(tmpPath)
     await v8ToIstanbul.load()
+    v8ToIstanbul.preparedSourceMapSources[0].path.should.equal(absoluteSourceFilePath)
+    v8ToIstanbul.preparedSourceMapSources[1].path.should.equal(absoluteOtherSourceFilePath)
     v8ToIstanbul.scriptPath.should.equal(tmpPath)
   })
 


### PR DESCRIPTION
I am trying to fix #21 and `v8-to-istanbul: source-mappings from one to many files not yet supported`

Approach:

0. v8-to-istanbul.js expects only one file of the sourcemap to be parsed at the same time
1. create a new method and walk through all source files of the sourcemap and reset state (this. sourceTranspiled and this.source) before