### PR TITLE
fix: protect against undefined sourcesContent

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -55,7 +55,7 @@ module.exports = class V8ToIstanbul {
         // so use this inline one instead of trying to read the file off disk
         // Not sure what it means to have an array of more than 1 here so just ignore it
         // since we wouldn't know how to handle it
-        if (this.sources.sourceMap && this.sources.sourceMap.sourcemap.sourcesContent.length === 1) {
+        if (this.sources.sourceMap && this.sources.sourceMap.sourcemap && this.sources.sourceMap.sourcemap.sourcesContent && this.sources.sourceMap.sourcemap.sourcesContent.length === 1) {
           originalRawSource = this.sources.sourceMap.sourcemap.sourcesContent[0]
         } else if (this.sources.originalSource) {
           originalRawSource = this.sources.originalSource


### PR DESCRIPTION
It was possible for `this.sources.sourceMap.sourcemap.sourcesContent` to be undefined.