### PR TITLE
Add support for 1:many source maps

### DIFF
--- a/lib/line.js
+++ b/lib/line.js
@@ -1,5 +1,5 @@
 module.exports = class CovLine {
-  constructor (line, startCol, lineStr) {
+  constructor(line, startCol, lineStr) {
     this.line = line
     // note that startCol and endCol are absolute positions
     // within a file, not relative to the line.
@@ -13,13 +13,13 @@ module.exports = class CovLine {
 
     // we start with all lines having been executed, and work
     // backwards zeroing out lines based on V8 output.
-    this.count = 1
+    // this.count = 1
 
     // set by source.js during parsing, if /* c8 ignore next */ is found.
     this.ignore = false
   }
 
-  toIstanbul () {
+  toIstanbul() {
     return {
       start: {
         line: this.line,

--- a/lib/line.js
+++ b/lib/line.js
@@ -1,5 +1,5 @@
 module.exports = class CovLine {
-  constructor(line, startCol, lineStr) {
+  constructor (line, startCol, lineStr) {
     this.line = line
     // note that startCol and endCol are absolute positions
     // within a file, not relative to the line.
@@ -13,17 +13,17 @@ module.exports = class CovLine {
 
     // we start with all lines having been executed, and work
     // backwards zeroing out lines based on V8 output.
-    this.count = 0
+    this.count = 1
 
     // set by source.js during parsing, if /* c8 ignore next */ is found.
     this.ignore = false
   }
 
-  toIstanbul() {
+  toIstanbul () {
     return {
       start: {
         line: this.line,
-        column: 1
+        column: 0
       },
       end: {
         line: this.line,

--- a/lib/line.js
+++ b/lib/line.js
@@ -13,7 +13,7 @@ module.exports = class CovLine {
 
     // we start with all lines having been executed, and work
     // backwards zeroing out lines based on V8 output.
-    // this.count = 1
+    this.count = 0
 
     // set by source.js during parsing, if /* c8 ignore next */ is found.
     this.ignore = false
@@ -23,7 +23,7 @@ module.exports = class CovLine {
     return {
       start: {
         line: this.line,
-        column: 0
+        column: 1
       },
       end: {
         line: this.line,

--- a/lib/source.js
+++ b/lib/source.js
@@ -11,7 +11,7 @@ module.exports = class CovSource {
     this._buildLines(sourceRaw)
   }
 
-  _buildLines(source) {
+  _buildLines (source) {
     let position = 0
     let ignoreCount = 0
     for (const [i, lineStr] of source.split(/(?<=\r?\n)/u).entries()) {
@@ -27,7 +27,7 @@ module.exports = class CovSource {
     }
   }
 
-  _parseIgnoreNext(lineStr, line) {
+  _parseIgnoreNext (lineStr, line) {
     const testIgnoreNextLines = lineStr.match(/^\W*\/\* c8 ignore next (?<count>[0-9]+)? *\*\/\W*$/)
     if (testIgnoreNextLines) {
       line.ignore = true
@@ -47,7 +47,7 @@ module.exports = class CovSource {
 
   // given a start column and end column in absolute offsets within
   // a source file (0 - EOF), returns the relative line column positions.
-  offsetToOriginalRelative(sourceMap, startCol, endCol) {
+  offsetToOriginalRelative (sourceMap, startCol, endCol) {
     const lines = this.lines.filter((line, i) => {
       return startCol <= line.endCol && endCol >= line.startCol
     })
@@ -75,9 +75,9 @@ module.exports = class CovSource {
         thisEndCol - lines[thisEndLine].startCol
       )
 
-      const isGoingForward = thisEnd && thisStart && thisEnd.line >= thisStart.line && (thisEnd.line > thisStart.line || thisEnd.column >= thisStart.column);
+      const isGoingForward = thisEnd && thisStart && thisEnd.line >= thisStart.line && (thisEnd.line > thisStart.line || thisEnd.column >= thisStart.column)
       if (thisEnd && thisEnd.source === thisStart.source && thisEndCol !== endCol && isGoingForward) {
-        lastEnd = thisEnd;
+        lastEnd = thisEnd
       } else {
         if (lastEnd && thisStart.source) {
           // ignore 0 length maps?
@@ -90,7 +90,7 @@ module.exports = class CovSource {
             relEndCol: lastEnd.column
           })
           //}
-          lastEnd = null;
+          lastEnd = null
         }
         thisStart = sourceMap.originalPositionFor({
           line: lines[thisEndLine].line,
@@ -104,7 +104,7 @@ module.exports = class CovSource {
         // TODO IS the below needed any more? and the condition above
         // if a newline is 2 characters (CRLF) then skip through it
         while (thisEndCol <= endCol && thisEndCol - lines[thisEndLine].startCol < 0) {
-          thisEndCol++;
+          thisEndCol++
         }
       }
     }
@@ -112,7 +112,7 @@ module.exports = class CovSource {
     return returnLocs
   }
 
-  relativeToOffset(line, relCol) {
+  relativeToOffset (line, relCol) {
     line = Math.max(line, 1)
     if (this.lines[line - 1] === undefined) return this.eof
     return Math.min(this.lines[line - 1].startCol + relCol, this.lines[line - 1].endCol)
@@ -140,7 +140,7 @@ module.exports = class CovSource {
  *    that generated range.
  * 3. Find the _end_ location of that original range.
  */
-function originalEndPositionFor(sourceMap, line, column) {
+function originalEndPositionFor (sourceMap, line, column) {
   // Given the generated location, find the original location of the mapping
   // that corresponds to a range on the generated file that overlaps the
   // generated file end location. Note however that this position on its
@@ -195,7 +195,7 @@ function originalEndPositionFor(sourceMap, line, column) {
   }
 }
 
-function getShebangLength(source) {
+function getShebangLength (source) {
   if (source.indexOf('#!') === 0) {
     const match = source.match(/(?<shebang>#!.*)/)
     if (match) {

--- a/lib/source.js
+++ b/lib/source.js
@@ -47,7 +47,7 @@ module.exports = class CovSource {
 
   // given a start column and end column in absolute offsets within
   // a source file (0 - EOF), returns the relative line column positions.
-  offsetToOriginalRelative (sourceMap, startCol, endCol) {
+  offsetToOriginalRelative (sourceMapScanner, startCol, endCol) {
     const lines = this.lines.filter((line, i) => {
       return startCol <= line.endCol && endCol >= line.startCol
     })
@@ -55,61 +55,108 @@ module.exports = class CovSource {
       return []
     }
 
-    let thisEndCol = startCol + 1
-    let thisEndLine = 0
-    if (lines[thisEndLine].endCol < thisEndCol) {
-      thisEndLine++
+    const sourceMapIterator = sourceMapScanner.getIterator()
+    let start = sourceMapIterator.scanTo(lines[0].line, startCol - lines[0].startCol)
+    let last = start
+    let endPos = { line: lines[lines.length - 1].line, col: endCol - lines[lines.length - 1].startCol }
+    let returnLocs = []
+    while (true) {
+      let next = sourceMapIterator.next()
+      const isPastEnd = !next || sourceMapIterator.isGeneratedAfter(next, endPos.line, endPos.col)
+
+      if (isPastEnd || next.source !== start.source ||
+        next.originalLine < start.originalLine ||
+        (next.originalLine === start.originalLine && next.originalColumn < start.originalColumn)) {
+        if (last !== start) {
+          returnLocs.push({
+            sourceFile: start.source,
+            startLine: start.originalLine,
+            relStartCol: start.originalColumn,
+            endLine: last.originalLine,
+            relEndCol: last.originalColumn
+          })
+        }
+        if (isPastEnd) {
+          break
+        }
+        start = next
+      } else {
+
+        // now we now we aren't going past the start (or different source) or the end etc.
+        // if the next token is going back past the last, ignore it.
+        if (next.originalLine < last.originalLine ||
+          (next.originalLine === last.originalLine && next.originalColumn < last.originalColumn)) {
+          continue
+        }
+      }
+
+      last = next
     }
-    let lastEnd
-    let thisStart = sourceMap.originalPositionFor({
-      line: lines[0].line,
-      column: startCol - lines[0].startCol,
-      bias: GREATEST_LOWER_BOUND
+    return this._removeOverlapping(returnLocs)
+  }
+
+  // minimize overlapping ranges to avoid bumping up the branches/functions count unless very necessary
+  _removeOverlapping (returnLocs) {
+    if (returnLocs.length <= 1) {
+      return returnLocs
+    }
+    const bySource = Object.create(null)
+    returnLocs.forEach((loc) => {
+      if (!bySource[loc.source]) {
+        bySource[loc.source] = []
+      }
+      bySource[loc.source].push(loc)
     })
 
-    let returnLocs = []
-    while (thisEndCol <= endCol) {
-      const thisEnd = originalEndPositionFor(
-        sourceMap,
-        lines[thisEndLine].line,
-        thisEndCol - lines[thisEndLine].startCol
-      )
+    const dedupedLocs = []
+    Object.keys(bySource).forEach((source) => {
+      let locs = bySource[source]
+      while (locs.length) {
+        const loc1 = locs.pop()
+        let isOverlapped = false
 
-      const isGoingForward = thisEnd && thisStart && thisEnd.line >= thisStart.line && (thisEnd.line > thisStart.line || thisEnd.column >= thisStart.column)
-      if (thisEnd && thisEnd.source === thisStart.source && thisEndCol !== endCol && isGoingForward) {
-        lastEnd = thisEnd
-      } else {
-        if (lastEnd && thisStart.source) {
-          // ignore 0 length maps?
-          //if (thisStart.line !== lastEnd.line && thisStart.column !== lastEnd.column) {
-          returnLocs.push({
-            sourceFile: thisStart.source,
-            startLine: thisStart.line,
-            relStartCol: thisStart.column,
-            endLine: lastEnd.line,
-            relEndCol: lastEnd.column
-          })
-          //}
-          lastEnd = null
-        }
-        thisStart = sourceMap.originalPositionFor({
-          line: lines[thisEndLine].line,
-          column: thisEndCol - lines[thisEndLine].startCol,
-          bias: GREATEST_LOWER_BOUND
-        })
-      }
-      thisEndCol++
-      if (thisEndCol <= endCol && lines[thisEndLine].endCol < thisEndCol) {
-        thisEndLine++
-        // TODO IS the below needed any more? and the condition above
-        // if a newline is 2 characters (CRLF) then skip through it
-        while (thisEndCol <= endCol && thisEndCol - lines[thisEndLine].startCol < 0) {
-          thisEndCol++
-        }
-      }
-    }
+        for (let i = 0; i < locs.length; i++) {
+          const loc2 = locs[i]
+          if (loc2 === loc1) {
+            return
+          }
 
-    return returnLocs
+          let isEndLoc1BeforeLoc2Start = ((loc1.endLine < loc2.startLine) || (loc1.endLine === loc2.startLine && loc1.relEndCol < loc2.relStartCol))
+          let isEndLoc2BeforeLoc1Start = ((loc2.endLine < loc1.startLine) || (loc1.endLine === loc2.startLine && loc2.relEndCol < loc1.relStartCol))
+
+          // |A...|B...|A..|B
+          // |A...|B...|B..|A
+          // |B...|A...|B..|A
+          // |B...|A...|A..|B
+          // |A...|A...|B..|B // isEndLoc1BeforeLoc2Start
+          // |B...|B...|A..|A // isEndLoc2BeforeLoc1Start
+
+          if (!(isEndLoc1BeforeLoc2Start || isEndLoc2BeforeLoc1Start)) {
+            const isStartAfter = ((loc1.startLine > loc2.startLine) || (loc1.startLine === loc2.startLine && loc1.relStartCol >= loc2.relStartCol))
+            const isEndAfter = ((loc1.endLine > loc2.endLine) || (loc1.endLine === loc2.endLine && loc1.relEndCol >= loc2.relEndCol))
+
+            const start = isStartAfter ? loc2 : loc1
+            const end = isEndAfter ? loc1 : loc2
+            locs.splice(i, 1)
+            locs.push({
+              source: start.source,
+              startLine: start.startLine,
+              relStartCol: start.relStartCol,
+              endLine: end.endLine,
+              relEndCol: end.relEndCol,
+            })
+            isOverlapped = true
+            break
+          }
+        }
+
+        if (!isOverlapped) {
+          dedupedLocs.push(loc1)
+        }
+      }
+    })
+
+    return dedupedLocs
   }
 
   relativeToOffset (line, relCol) {

--- a/lib/source.js
+++ b/lib/source.js
@@ -52,95 +52,64 @@ module.exports = class CovSource {
       return startCol <= line.endCol && endCol >= line.startCol
     })
     if (!lines.length) {
-      console.log('unable to find lines?!')
       return []
     }
 
-    // this range covers multiple files, so we need to split it up
-    let hasTsx = false;
-    let thisStartCol = startCol;
-    let thisStartLine = 0;
-    let thisEndCol = startCol + 1;
-    let thisEndLine = 0;
-    let lastEndLine = thisEndLine;
-    if (lines[thisEndLine].endCol <= thisEndCol) {
-      thisEndLine++;
+    let thisEndCol = startCol + 1
+    let thisEndLine = 0
+    if (lines[thisEndLine].endCol < thisEndCol) {
+      thisEndLine++
     }
-    let lastEnd;
-    let thisStart = originalPositionTryBoth(
-      sourceMap,
-      lines[0].line,
-      startCol - lines[0].startCol
-    );
-    let returnLocs = [];
+    let lastEnd
+    let thisStart = sourceMap.originalPositionFor({
+      line: lines[0].line,
+      column: startCol - lines[0].startCol,
+      bias: GREATEST_LOWER_BOUND
+    })
+
+    let returnLocs = []
     while (thisEndCol <= endCol) {
       const thisEnd = originalEndPositionFor(
         sourceMap,
         lines[thisEndLine].line,
         thisEndCol - lines[thisEndLine].startCol
-      );
+      )
 
       const isGoingForward = thisEnd && thisStart && thisEnd.line >= thisStart.line && (thisEnd.line > thisStart.line || thisEnd.column >= thisStart.column);
       if (thisEnd && thisEnd.source === thisStart.source && thisEndCol !== endCol && isGoingForward) {
         lastEnd = thisEnd;
       } else {
-        // Give up if we werent previously valid to ignore non mapped blocks inside the region
         if (lastEnd && thisStart.source) {
-
-          if (thisStart.line === lastEnd.line && thisStart.column === lastEnd.column) {
-            const potentialLastEnd = sourceMap.originalPositionFor({
-              line: lines[lastEndLine].line,
-              column: (thisEndCol - 1) - lines[lastEndLine].startCol,
-              bias: LEAST_UPPER_BOUND
-            })
-            potentialLastEnd.column -= 1
-            if (lastEnd.source === potentialLastEnd.source) {
-              lastEnd = potentialLastEnd
-            }
-          }
-
-          // ignore 0 length maps
+          // ignore 0 length maps?
           //if (thisStart.line !== lastEnd.line && thisStart.column !== lastEnd.column) {
-          if (thisStart.source.indexOf('tsx') >= 0) {
-            /*            console.log(thisStartCol + '(' + startCol + ')', ':', thisEndCol + '(' + endCol + ')',
-                          { l: lines[thisStartLine].line, c: thisStartCol - lines[thisStartLine].startCol },
-                          { l: lines[lastEndLine].line, c: (thisEndCol - 1) - lines[lastEndLine].startCol },
-                          '->', thisStart.source, { l: thisStart.line, c: thisStart.column }, { l: lastEnd.line, c: lastEnd.column })*/
-            hasTsx = true;
-          }
           returnLocs.push({
             sourceFile: thisStart.source,
             startLine: thisStart.line,
             relStartCol: thisStart.column,
             endLine: lastEnd.line,
             relEndCol: lastEnd.column
-          });
+          })
           //}
-          //console.log('found range', returnLocs[returnLocs.length - 1]);
           lastEnd = null;
-        } else {
-          //console.log('something broken', lastEnd, thisStart.source)
         }
-        thisStartCol = thisEndCol;
-        thisStartLine = thisEndLine;
-        thisStart = originalPositionTryBoth(
-          sourceMap,
-          lines[thisEndLine].line,
-          Math.max(0, thisEndCol - lines[thisEndLine].startCol)
-        );
+        thisStart = sourceMap.originalPositionFor({
+          line: lines[thisEndLine].line,
+          column: thisEndCol - lines[thisEndLine].startCol,
+          bias: GREATEST_LOWER_BOUND
+        })
       }
-      thisEndCol++;
-      lastEndLine = thisEndLine;
-      if (lines[thisEndLine].endCol < thisEndCol) {
-        thisEndLine++;
+      thisEndCol++
+      if (thisEndCol <= endCol && lines[thisEndLine].endCol < thisEndCol) {
+        thisEndLine++
+        // TODO IS the below needed any more? and the condition above
+        // if a newline is 2 characters (CRLF) then skip through it
+        while (thisEndCol <= endCol && thisEndCol - lines[thisEndLine].startCol < 0) {
+          thisEndCol++;
+        }
       }
     }
 
-    if (hasTsx && returnLocs.length > 1) {
-      console.log('non minimized has multi-ranges')
-    }
-
-    return returnLocs;
+    return returnLocs
   }
 
   relativeToOffset(line, relCol) {
@@ -177,11 +146,11 @@ function originalEndPositionFor(sourceMap, line, column) {
   // generated file end location. Note however that this position on its
   // own is not useful because it is the position of the _start_ of the range
   // on the original file, and we want the _end_ of the range.
-  const beforeEndMapping = originalPositionTryBoth(
-    sourceMap,
+  const beforeEndMapping = sourceMap.originalPositionFor({
     line,
-    Math.max(column - 1, 1)
-  )
+    column,
+    bias: LEAST_UPPER_BOUND
+  })
 
   if (beforeEndMapping.source === null) {
     return null
@@ -196,8 +165,10 @@ function originalEndPositionFor(sourceMap, line, column) {
     source: beforeEndMapping.source,
     line: beforeEndMapping.line,
     column: beforeEndMapping.column + 1,
-    bias: LEAST_UPPER_BOUND
+    bias: GREATEST_LOWER_BOUND
   })
+  const afterOriginalPos = afterEndMapping.line !== null && sourceMap.originalPositionFor(afterEndMapping)
+
   if (
     // If this is null, it means that we've hit the end of the file,
     // so we can use Infinity as the end column.
@@ -205,8 +176,8 @@ function originalEndPositionFor(sourceMap, line, column) {
     // If these don't match, it means that the call to
     // 'generatedPositionFor' didn't find any other original mappings on
     // the line we gave, so consider the binding to extend to infinity.
-    sourceMap.originalPositionFor(afterEndMapping).line !==
-    beforeEndMapping.line
+    afterOriginalPos.line !== beforeEndMapping.line ||
+    afterOriginalPos.source !== beforeEndMapping.source
   ) {
     return {
       source: beforeEndMapping.source,
@@ -216,29 +187,12 @@ function originalEndPositionFor(sourceMap, line, column) {
   }
 
   // Convert the end mapping into the real original position.
-  return sourceMap.originalPositionFor(afterEndMapping)
-}
 
-function originalPositionTryBoth(sourceMap, line, column) {
-  let original = sourceMap.originalPositionFor({
-    line,
-    column,
-    bias: GREATEST_LOWER_BOUND
-  })
-  if (original.line === null) {
-    original = sourceMap.originalPositionFor({
-      line,
-      column,
-      bias: LEAST_UPPER_BOUND
-    })
+  return {
+    source: afterOriginalPos.source,
+    line: afterOriginalPos.line - (afterOriginalPos.column === 0 ? 1 : 0),
+    column: afterOriginalPos.column === 0 ? Infinity : afterOriginalPos.column
   }
-
-  if (original && original.source && original.source.indexOf('tsx') > 0) {
-    // console.log({ line, column }, 'became', original)
-  }
-
-  return original
-
 }
 
 function getShebangLength(source) {

--- a/lib/source.js
+++ b/lib/source.js
@@ -2,7 +2,7 @@ const CovLine = require('./line')
 const { GREATEST_LOWER_BOUND, LEAST_UPPER_BOUND } = require('source-map').SourceMapConsumer
 
 module.exports = class CovSource {
-  constructor (sourceRaw, wrapperLength) {
+  constructor(sourceRaw, wrapperLength) {
     sourceRaw = sourceRaw.trimEnd()
     this.lines = []
     this.eof = sourceRaw.length
@@ -11,7 +11,7 @@ module.exports = class CovSource {
     this._buildLines(sourceRaw)
   }
 
-  _buildLines (source) {
+  _buildLines(source) {
     let position = 0
     let ignoreCount = 0
     for (const [i, lineStr] of source.split(/(?<=\r?\n)/u).entries()) {
@@ -27,7 +27,7 @@ module.exports = class CovSource {
     }
   }
 
-  _parseIgnoreNext (lineStr, line) {
+  _parseIgnoreNext(lineStr, line) {
     const testIgnoreNextLines = lineStr.match(/^\W*\/\* c8 ignore next (?<count>[0-9]+)? *\*\/\W*$/)
     if (testIgnoreNextLines) {
       line.ignore = true
@@ -47,53 +47,97 @@ module.exports = class CovSource {
 
   // given a start column and end column in absolute offsets within
   // a source file (0 - EOF), returns the relative line column positions.
-  offsetToOriginalRelative (sourceMap, startCol, endCol) {
+  offsetToOriginalRelative(sourceMap, startCol, endCol) {
     const lines = this.lines.filter((line, i) => {
       return startCol <= line.endCol && endCol >= line.startCol
     })
-    if (!lines.length) return {}
+    if (!lines.length) {
+      console.log('unable to find lines?!')
+      return []
+    }
 
-    const start = originalPositionTryBoth(
+    // this range covers multiple files, so we need to split it up
+    let thisStartCol = startCol;
+    let thisStartLine = 0;
+    let thisEndCol = startCol + 1;
+    let thisEndLine = 0;
+    let lastEndLine = thisEndLine;
+    if (lines[thisEndLine].endCol <= thisEndCol) {
+      thisEndLine++;
+    }
+    let lastEnd;
+    let thisStart = originalPositionTryBoth(
       sourceMap,
       lines[0].line,
       startCol - lines[0].startCol
-    )
-    let end = originalEndPositionFor(
-      sourceMap,
-      lines[lines.length - 1].line,
-      endCol - lines[lines.length - 1].startCol
-    )
+    );
+    let returnLocs = [];
+    while (thisEndCol <= endCol) {
+      const thisEnd = originalEndPositionFor(
+        sourceMap,
+        lines[thisEndLine].line,
+        thisEndCol - lines[thisEndLine].startCol
+      );
 
-    if (!(start && end)) {
-      return {}
+      const isGoingForward = thisEnd && thisStart && thisEnd.line >= thisStart.line && (thisEnd.line > thisStart.line || thisEnd.column >= thisStart.column);
+      if (thisEnd && thisEnd.source === thisStart.source && thisEndCol !== endCol && isGoingForward) {
+        lastEnd = thisEnd;
+      } else {
+        // Give up if we werent previously valid to ignore non mapped blocks inside the region
+        if (lastEnd && thisStart.source) {
+
+          if (thisStart.line === lastEnd.line && thisStart.column === lastEnd.column) {
+            const potentialLastEnd = sourceMap.originalPositionFor({
+              line: lines[lastEndLine].line,
+              column: (thisEndCol - 1) - lines[lastEndLine].startCol,
+              bias: LEAST_UPPER_BOUND
+            })
+            potentialLastEnd.column -= 1
+            if (lastEnd.source === potentialLastEnd.source) {
+              lastEnd = potentialLastEnd
+            }
+          }
+
+          // ignore 0 length maps
+          //if (thisStart.line !== lastEnd.line && thisStart.column !== lastEnd.column) {
+          if (thisStart.source.indexOf('App.tsx') >= 0) {
+            console.log(thisStartCol + '(' + startCol + ')', ':', thisEndCol + '(' + endCol + ')',
+              { l: lines[thisStartLine].line, c: thisStartCol - lines[thisStartLine].startCol },
+              { l: lines[lastEndLine].line, c: (thisEndCol - 1) - lines[lastEndLine].startCol },
+              '->', thisStart.source, { l: thisStart.line, c: thisStart.column }, { l: lastEnd.line, c: lastEnd.column })
+          }
+          returnLocs.push({
+            sourceFile: thisStart.source,
+            startLine: thisStart.line,
+            relStartCol: thisStart.column,
+            endLine: lastEnd.line,
+            relEndCol: lastEnd.column
+          });
+          //}
+          //console.log('found range', returnLocs[returnLocs.length - 1]);
+          lastEnd = null;
+        } else {
+          //console.log('something broken', lastEnd, thisStart.source)
+        }
+        thisStartCol = thisEndCol;
+        thisStartLine = thisEndLine;
+        thisStart = originalPositionTryBoth(
+          sourceMap,
+          lines[thisEndLine].line,
+          Math.max(0, thisEndCol - lines[thisEndLine].startCol)
+        );
+      }
+      thisEndCol++;
+      lastEndLine = thisEndLine;
+      if (lines[thisEndLine].endCol < thisEndCol) {
+        thisEndLine++;
+      }
     }
 
-    if (!(start.source && end.source)) {
-      return {}
-    }
-
-    if (start.source !== end.source) {
-      return {}
-    }
-
-    if (start.line === end.line && start.column === end.column) {
-      end = sourceMap.originalPositionFor({
-        line: lines[lines.length - 1].line,
-        column: endCol - lines[lines.length - 1].startCol,
-        bias: LEAST_UPPER_BOUND
-      })
-      end.column -= 1
-    }
-
-    return {
-      startLine: start.line,
-      relStartCol: start.column,
-      endLine: end.line,
-      relEndCol: end.column
-    }
+    return returnLocs;
   }
 
-  relativeToOffset (line, relCol) {
+  relativeToOffset(line, relCol) {
     line = Math.max(line, 1)
     if (this.lines[line - 1] === undefined) return this.eof
     return Math.min(this.lines[line - 1].startCol + relCol, this.lines[line - 1].endCol)
@@ -121,7 +165,7 @@ module.exports = class CovSource {
  *    that generated range.
  * 3. Find the _end_ location of that original range.
  */
-function originalEndPositionFor (sourceMap, line, column) {
+function originalEndPositionFor(sourceMap, line, column) {
   // Given the generated location, find the original location of the mapping
   // that corresponds to a range on the generated file that overlaps the
   // generated file end location. Note however that this position on its
@@ -149,14 +193,14 @@ function originalEndPositionFor (sourceMap, line, column) {
     bias: LEAST_UPPER_BOUND
   })
   if (
-  // If this is null, it means that we've hit the end of the file,
-  // so we can use Infinity as the end column.
+    // If this is null, it means that we've hit the end of the file,
+    // so we can use Infinity as the end column.
     afterEndMapping.line === null ||
-      // If these don't match, it means that the call to
-      // 'generatedPositionFor' didn't find any other original mappings on
-      // the line we gave, so consider the binding to extend to infinity.
-      sourceMap.originalPositionFor(afterEndMapping).line !==
-          beforeEndMapping.line
+    // If these don't match, it means that the call to
+    // 'generatedPositionFor' didn't find any other original mappings on
+    // the line we gave, so consider the binding to extend to infinity.
+    sourceMap.originalPositionFor(afterEndMapping).line !==
+    beforeEndMapping.line
   ) {
     return {
       source: beforeEndMapping.source,
@@ -169,24 +213,29 @@ function originalEndPositionFor (sourceMap, line, column) {
   return sourceMap.originalPositionFor(afterEndMapping)
 }
 
-function originalPositionTryBoth (sourceMap, line, column) {
-  const original = sourceMap.originalPositionFor({
+function originalPositionTryBoth(sourceMap, line, column) {
+  let original = sourceMap.originalPositionFor({
     line,
     column,
     bias: GREATEST_LOWER_BOUND
   })
   if (original.line === null) {
-    return sourceMap.originalPositionFor({
+    original = sourceMap.originalPositionFor({
       line,
       column,
       bias: LEAST_UPPER_BOUND
     })
-  } else {
-    return original
   }
+
+  if (original && original.source && original.source.indexOf('tsx') > 0) {
+    // console.log({ line, column }, 'became', original)
+  }
+
+  return original
+
 }
 
-function getShebangLength (source) {
+function getShebangLength(source) {
   if (source.indexOf('#!') === 0) {
     const match = source.match(/(?<shebang>#!.*)/)
     if (match) {

--- a/lib/source.js
+++ b/lib/source.js
@@ -57,6 +57,7 @@ module.exports = class CovSource {
     }
 
     // this range covers multiple files, so we need to split it up
+    let hasTsx = false;
     let thisStartCol = startCol;
     let thisStartLine = 0;
     let thisEndCol = startCol + 1;
@@ -100,11 +101,12 @@ module.exports = class CovSource {
 
           // ignore 0 length maps
           //if (thisStart.line !== lastEnd.line && thisStart.column !== lastEnd.column) {
-          if (thisStart.source.indexOf('App.tsx') >= 0) {
-            console.log(thisStartCol + '(' + startCol + ')', ':', thisEndCol + '(' + endCol + ')',
-              { l: lines[thisStartLine].line, c: thisStartCol - lines[thisStartLine].startCol },
-              { l: lines[lastEndLine].line, c: (thisEndCol - 1) - lines[lastEndLine].startCol },
-              '->', thisStart.source, { l: thisStart.line, c: thisStart.column }, { l: lastEnd.line, c: lastEnd.column })
+          if (thisStart.source.indexOf('tsx') >= 0) {
+            /*            console.log(thisStartCol + '(' + startCol + ')', ':', thisEndCol + '(' + endCol + ')',
+                          { l: lines[thisStartLine].line, c: thisStartCol - lines[thisStartLine].startCol },
+                          { l: lines[lastEndLine].line, c: (thisEndCol - 1) - lines[lastEndLine].startCol },
+                          '->', thisStart.source, { l: thisStart.line, c: thisStart.column }, { l: lastEnd.line, c: lastEnd.column })*/
+            hasTsx = true;
           }
           returnLocs.push({
             sourceFile: thisStart.source,
@@ -132,6 +134,10 @@ module.exports = class CovSource {
       if (lines[thisEndLine].endCol < thisEndCol) {
         thisEndLine++;
       }
+    }
+
+    if (hasTsx && returnLocs.length > 1) {
+      console.log('non minimized has multi-ranges')
     }
 
     return returnLocs;

--- a/lib/sourcemapScanner.js
+++ b/lib/sourcemapScanner.js
@@ -1,0 +1,74 @@
+class SourceMapScannerIterator {
+    constructor(mappings) {
+        this.mappings = mappings
+        this.index = 0
+    }
+
+    _binarySearchStart (startLine, startCol, startIndex, endIndex) {
+        if (startIndex === endIndex) {
+            return startIndex
+        }
+        const midPoint = Math.floor((endIndex + startIndex) / 2)
+        if (this.isGeneratedAfter(this.mappings[midPoint], startLine, startCol)) {
+            // generated point is after point we are looking for, so exclude is (midPoint - 1)
+            return this._binarySearchStart(startLine, startCol, 0, Math.max(0, midPoint - 1))
+        } else {
+            // if we are down to 2 points
+            // find 4 in 1 3 5
+            // midpoint = 1 -> 3
+            // if 3 is after 4 - false
+            // 1,2
+            // 
+            if (endIndex - midPoint === 1) {
+                return midPoint
+            }
+            // generated point is before the point we are looking for, so might be valid, so include it
+            return this._binarySearchStart(startLine, startCol, midPoint, endIndex)
+        }
+    }
+
+    isGeneratedAfter (mapping, line, col) {
+        return mapping.generatedLine > line ||
+            (mapping.generatedLine === line && mapping.generatedColumn > col)
+    }
+
+    scanTo (startLine, startCol) {
+        this.index = this._binarySearchStart(startLine, startCol, 0, this.mappings.length - 1)
+
+        // make sure we have the first mapping for this exact position
+        while (this.index > 0 &&
+            this.mappings[this.index].generatedLine === this.mappings[this.index - 1].generatedLine &&
+            this.mappings[this.index].generatedColumn === this.mappings[this.index - 1].generatedColumn) {
+            this.index--
+        }
+
+        return this.mappings[this.index]
+    }
+
+    next () {
+        return this.mappings[++this.index]
+    }
+
+    peek () {
+        return this.mappings[this.index + 1]
+    }
+}
+
+module.exports = class SourceMapScanner {
+    constructor(sourcemap) {
+        // [{ source: 'illmatic.js',
+        //   generatedLine: 1,
+        //   generatedColumn: 0,
+        //   originalLine: 1,
+        //   originalColumn: 0,
+        //   name: null }]
+        this.mappings = []
+        sourcemap.eachMapping((mapping) => {
+            this.mappings.push(mapping)
+        })
+    }
+
+    getIterator () {
+        return new SourceMapScannerIterator(this.mappings)
+    }
+}

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -4,6 +4,7 @@ const { dirname, isAbsolute, join, resolve } = require('path')
 const CovBranch = require('./branch')
 const CovFunction = require('./function')
 const CovSource = require('./source')
+const SourceMapScanner = require('./sourcemapScanner')
 const compatError = Error(`requires Node.js ${require('../package.json').engines.node}`)
 let readFile = () => { throw compatError }
 try {
@@ -41,6 +42,7 @@ module.exports = class V8ToIstanbul {
 
     if (rawSourceMap) {
       this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
+      this.sourceMapScanner = new SourceMapScanner(this.sourceMap)
       const sourceRoot = rawSourceMap.sourcemap.sourceRoot
 
       for (let i = 0; i < rawSourceMap.sourcemap.sources.length; i++) {
@@ -95,62 +97,62 @@ module.exports = class V8ToIstanbul {
     blocks.forEach(block => {
       block.ranges.forEach((range, i) => {
         const subRanges = this._maybeRemapStartColEndCol(range)
+        if (!subRanges.length) {
+          return
+        }
+        const startRange = subRanges[0]
+        const endRange = subRanges[subRanges.length - 1]
+        const { source, functions, branches } = startRange.fileInfo
+        const lines = source.lines.filter(line => {
+          // Upstream tooling can provide a block with the functionName
+          // (empty-report), this will result in a report that has all
+          // lines zeroed out.
+          if (block.functionName === '(empty-report)') {
+            line.count = 0
+            return true
+          }
+          return startRange.startCol <= line.endCol && endRange.endCol >= line.startCol
+        })
+        const startLineInstance = lines[0]
+        const endLineInstance = lines[lines.length - 1]
+        const rangeArgument = [
+          startLineInstance.line,
+          startRange.startCol - startLineInstance.startCol,
+          endLineInstance.line,
+          endRange.endCol - endLineInstance.startCol,
+        ]
+
+        if (block.isBlockCoverage && lines.length) {
+          // record branches.
+          branches.push(new CovBranch(
+            ...rangeArgument,
+            range.count
+          ))
+
+          // if block-level granularity is enabled, we we still create a single
+          // CovFunction tracking object for each set of ranges.
+          if (block.functionName && i === 0) {
+            functions.push(new CovFunction(
+              block.functionName,
+              ...rangeArgument,
+              range.count
+            ))
+          }
+        } else if (block.functionName && lines.length) {
+          // record functions.
+          functions.push(new CovFunction(
+            block.functionName,
+            ...rangeArgument,
+            range.count
+          ))
+        }
+
         subRanges.forEach((subRange) => {
           const {
             startCol,
             endCol,
-            fileInfo
           } = subRange
-          if (!fileInfo) {
-            return
-          }
-          const { source, functions, branches } = fileInfo
-          const lines = source.lines.filter(line => {
-            // Upstream tooling can provide a block with the functionName
-            // (empty-report), this will result in a report that has all
-            // lines zeroed out.
-            if (block.functionName === '(empty-report)') {
-              line.count = 0
-              return true
-            }
-            return startCol <= line.endCol && endCol >= line.startCol
-          })
-          const startLineInstance = lines[0]
-          const endLineInstance = lines[lines.length - 1]
 
-          if (block.isBlockCoverage && lines.length) {
-            // record branches.
-            branches.push(new CovBranch(
-              startLineInstance.line,
-              startCol - startLineInstance.startCol,
-              endLineInstance.line,
-              endCol - endLineInstance.startCol,
-              range.count
-            ))
-
-            // if block-level granularity is enabled, we we still create a single
-            // CovFunction tracking object for each set of ranges.
-            if (block.functionName && i === 0) {
-              functions.push(new CovFunction(
-                block.functionName,
-                startLineInstance.line,
-                startCol - startLineInstance.startCol,
-                endLineInstance.line,
-                endCol - endLineInstance.startCol,
-                range.count
-              ))
-            }
-          } else if (block.functionName && lines.length) {
-            // record functions.
-            functions.push(new CovFunction(
-              block.functionName,
-              startLineInstance.line,
-              startCol - startLineInstance.startCol,
-              endLineInstance.line,
-              endCol - endLineInstance.startCol,
-              range.count
-            ))
-          }
 
           // record the lines (we record these as statements, such that we're
           // compatible with Istanbul 2.0).
@@ -178,18 +180,19 @@ module.exports = class V8ToIstanbul {
       const endCol = Math.min(this.sourceTranspiled.eof, range.endOffset - this.sourceTranspiled.wrapperLength)
 
       const locs = this.sourceTranspiled.offsetToOriginalRelative(
-        this.sourceMap,
+        this.sourceMapScanner,
         startCol,
         endCol
       )
 
+      let firstSource
       return locs.map((loc) => {
         const { startLine, relStartCol, endLine, relEndCol, sourceFile } = loc
 
         const fileInfo = this.files[sourceFile]
 
         if (!fileInfo) {
-          return {}
+          return null
         }
 
         // next we convert these relative positions back to absolute positions
@@ -202,6 +205,20 @@ module.exports = class V8ToIstanbul {
           startCol,
           endCol
         }
+      }).filter((loc) => {
+        // filter out locations we don't have file info for
+        if (!loc) {
+          return false
+        }
+        // filter out all but the first source - its hard to manage a sngle coverage item going over multiple files
+        if (!firstSource) {
+          firstSource = loc.fileInfo.source
+        } else if (loc.fileInfo.source !== firstSource) {
+          return false
+        }
+        return true
+      }).sort((a, b) => {
+        return a.startCol > b.startCol ? 1 : -1
       })
     }
 

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -20,7 +20,7 @@ const isNode8 = /^v8\./.test(process.version)
 const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
 
 module.exports = class V8ToIstanbul {
-  constructor (scriptPath, wrapperLength, sources) {
+  constructor(scriptPath, wrapperLength, sources) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
     assert(!isNode8, 'This module does not support node 8 or lower, please upgrade to node 10')
     this.path = parsePath(scriptPath)
@@ -28,7 +28,7 @@ module.exports = class V8ToIstanbul {
     this.sources = sources || {}
     this.sourceMap = undefined
     this.sourceTranspiled = undefined
-    this.files = {};
+    this.files = {}
   }
 
   async load () {
@@ -41,7 +41,6 @@ module.exports = class V8ToIstanbul {
 
     if (rawSourceMap) {
       this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
-      this.sourceMap.computeColumnSpans()
       const sourceRoot = rawSourceMap.sourcemap.sourceRoot
 
       for (let i = 0; i < rawSourceMap.sourcemap.sources.length; i++) {
@@ -69,17 +68,17 @@ module.exports = class V8ToIstanbul {
     }
   }
 
-  _makeFileCoverage(path, source, resolvedPath = path) {
+  _makeFileCoverage (path, source, resolvedPath = path) {
     this.files[path] = {
       branches: [],
       functions: [],
       source,
       path,
       resolvedPath,
-    };
+    }
   }
 
-  _rewritePath(sourceRoot, sourcePath) {
+  _rewritePath (sourceRoot, sourcePath) {
     sourceRoot = sourceRoot ? sourceRoot.replace('file://', '') : ''
     sourcePath = sourcePath.replace('file://', '')
 
@@ -92,7 +91,7 @@ module.exports = class V8ToIstanbul {
     }
   }
 
-  applyCoverage(blocks) {
+  applyCoverage (blocks) {
     blocks.forEach(block => {
       block.ranges.forEach((range, i) => {
         const subRanges = this._maybeRemapStartColEndCol(range)
@@ -101,11 +100,11 @@ module.exports = class V8ToIstanbul {
             startCol,
             endCol,
             fileInfo
-          } = subRange;
+          } = subRange
           if (!fileInfo) {
-            return;
+            return
           }
-          const { source, functions, branches } = fileInfo;
+          const { source, functions, branches } = fileInfo
           const lines = source.lines.filter(line => {
             // Upstream tooling can provide a block with the functionName
             // (empty-report), this will result in a report that has all
@@ -173,7 +172,7 @@ module.exports = class V8ToIstanbul {
     })
   }
 
-  _maybeRemapStartColEndCol(range) {
+  _maybeRemapStartColEndCol (range) {
     if (this.sourceMap) {
       const startCol = Math.max(0, range.startOffset - this.sourceTranspiled.wrapperLength)
       const endCol = Math.min(this.sourceTranspiled.eof, range.endOffset - this.sourceTranspiled.wrapperLength)
@@ -182,15 +181,15 @@ module.exports = class V8ToIstanbul {
         this.sourceMap,
         startCol,
         endCol
-      );
+      )
 
       return locs.map((loc) => {
-        const { startLine, relStartCol, endLine, relEndCol, sourceFile } = loc;
+        const { startLine, relStartCol, endLine, relEndCol, sourceFile } = loc
 
-        const fileInfo = this.files[sourceFile];
+        const fileInfo = this.files[sourceFile]
 
         if (!fileInfo) {
-          return {};
+          return {}
         }
 
         // next we convert these relative positions back to absolute positions
@@ -203,10 +202,10 @@ module.exports = class V8ToIstanbul {
           startCol,
           endCol
         }
-      });
+      })
     }
 
-    const fileInfo = this.files[this.path];
+    const fileInfo = this.files[this.path]
     const startCol = Math.max(0, range.startOffset - fileInfo.source.wrapperLength)
     const endCol = Math.min(fileInfo.source.eof, range.endOffset - fileInfo.source.wrapperLength)
 
@@ -217,12 +216,12 @@ module.exports = class V8ToIstanbul {
     }]
   }
 
-  toIstanbul() {
+  toIstanbul () {
 
     const istanbulOuter = {}
     Object.keys(this.files).forEach((file) => {
 
-      const { resolvedPath, source, branches, functions } = this.files[file];
+      const { resolvedPath, source, branches, functions } = this.files[file]
 
       const istanbulInner = Object.assign(
         { path: resolvedPath },
@@ -231,7 +230,7 @@ module.exports = class V8ToIstanbul {
         this._functionsToIstanbul(source, functions)
       )
       istanbulOuter[resolvedPath] = istanbulInner
-    });
+    })
     return istanbulOuter
   }
 
@@ -260,7 +259,7 @@ module.exports = class V8ToIstanbul {
     return iBranches
   }
 
-  _functionsToIstanbul(source, functions) {
+  _functionsToIstanbul (source, functions) {
     const iFunctions = {
       fnMap: {},
       f: {}

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -20,7 +20,7 @@ const isNode8 = /^v8\./.test(process.version)
 const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
 
 module.exports = class V8ToIstanbul {
-  constructor(scriptPath, wrapperLength, sources) {
+  constructor (scriptPath, wrapperLength, sources) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
     assert(!isNode8, 'This module does not support node 8 or lower, please upgrade to node 10')
     this.path = parsePath(scriptPath)
@@ -31,7 +31,7 @@ module.exports = class V8ToIstanbul {
     this.files = {};
   }
 
-  async load() {
+  async load () {
     const rawSource = this.sources.source || await readFile(this.path, 'utf8')
     const rawSourceMap = this.sources.sourceMap ||
       // if we find a source-map (either inline, or a .map file) we load
@@ -41,11 +41,12 @@ module.exports = class V8ToIstanbul {
 
     if (rawSourceMap) {
       this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
-      const sourceRoot = rawSourceMap.sourcemap.sourceRoot;
+      this.sourceMap.computeColumnSpans()
+      const sourceRoot = rawSourceMap.sourcemap.sourceRoot
 
       for (let i = 0; i < rawSourceMap.sourcemap.sources.length; i++) {
         const originalPath = rawSourceMap.sourcemap.sources[i]
-        const resolvedPath = this._rewritePath(sourceRoot, originalPath);
+        const resolvedPath = this._rewritePath(sourceRoot, originalPath)
 
         let originalRawSource
         // If the source map has inline source content then it should be here
@@ -69,10 +70,6 @@ module.exports = class V8ToIstanbul {
   }
 
   _makeFileCoverage(path, source, resolvedPath = path) {
-    if (!source) {
-      throw new Error('no source passed');
-    }
-
     this.files[path] = {
       branches: [],
       functions: [],
@@ -193,25 +190,13 @@ module.exports = class V8ToIstanbul {
         const fileInfo = this.files[sourceFile];
 
         if (!fileInfo) {
-          console.log('did not find', sourceFile)
           return {};
-        }
-
-        if (fileInfo.resolvedPath.indexOf('.tsx') >= 0) {
-          //console.log('-------------')
-          //console.log(fileInfo.resolvedPath)
-          //console.log(range)
-          //console.log({ startLine, relStartCol, endLine, relEndCol });
         }
 
         // next we convert these relative positions back to absolute positions
         // in the original source (which is the format expected in the next step).
         const startCol = fileInfo.source.relativeToOffset(startLine, relStartCol)
         const endCol = fileInfo.source.relativeToOffset(endLine, relEndCol)
-
-        if (fileInfo.resolvedPath.indexOf('tsx') >= 0) {
-          // console.log({ startCol, endCol });
-        }
 
         return {
           fileInfo,
@@ -250,7 +235,7 @@ module.exports = class V8ToIstanbul {
     return istanbulOuter
   }
 
-  _statementsToIstanbul(source) {
+  _statementsToIstanbul (source) {
     const statements = {
       statementMap: {},
       s: {}
@@ -262,7 +247,7 @@ module.exports = class V8ToIstanbul {
     return statements
   }
 
-  _branchesToIstanbul(source, branches) {
+  _branchesToIstanbul (source, branches) {
     const iBranches = {
       branchMap: {},
       b: {}
@@ -289,6 +274,6 @@ module.exports = class V8ToIstanbul {
   }
 }
 
-function parsePath(scriptPath) {
+function parsePath (scriptPath) {
   return scriptPath.replace('file://', '')
 }

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -59,7 +59,12 @@ module.exports = class V8ToIstanbul {
         } else if (this.sources.originalSource) {
           originalRawSource = this.sources.originalSource
         } else {
-          originalRawSource = await readFile(resolvedPath, 'utf8')
+          try {
+            originalRawSource = await readFile(resolvedPath, 'utf8')
+          } catch(e) {
+            console.warn('failed to load source:', resolvedPath);
+            continue;
+          }
         }
 
         this._makeFileCoverage(originalPath, new CovSource(originalRawSource, this.wrapperLength), resolvedPath)

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -20,21 +20,18 @@ const isNode8 = /^v8\./.test(process.version)
 const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
 
 module.exports = class V8ToIstanbul {
-  constructor (scriptPath, wrapperLength, sources) {
+  constructor(scriptPath, wrapperLength, sources) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
     assert(!isNode8, 'This module does not support node 8 or lower, please upgrade to node 10')
     this.path = parsePath(scriptPath)
     this.wrapperLength = wrapperLength === undefined ? cjsWrapperLength : wrapperLength
     this.sources = sources || {}
-    this.generatedLines = []
-    this.branches = []
-    this.functions = []
     this.sourceMap = undefined
-    this.source = undefined
     this.sourceTranspiled = undefined
+    this.files = {};
   }
 
-  async load () {
+  async load() {
     const rawSource = this.sources.source || await readFile(this.path, 'utf8')
     const rawSourceMap = this.sources.sourceMap ||
       // if we find a source-map (either inline, or a .map file) we load
@@ -43,80 +40,113 @@ module.exports = class V8ToIstanbul {
       convertSourceMap.fromSource(rawSource) || convertSourceMap.fromMapFileSource(rawSource, dirname(this.path))
 
     if (rawSourceMap) {
-      if (rawSourceMap.sourcemap.sources.length > 1) {
-        console.warn('v8-to-istanbul: source-mappings from one to many files not yet supported')
-        this.source = new CovSource(rawSource, this.wrapperLength)
-      } else {
-        this._rewritePath(rawSourceMap)
-        this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
+      this.sourceMap = await new SourceMapConsumer(rawSourceMap.sourcemap)
+      const sourceRoot = rawSourceMap.sourcemap.sourceRoot;
+
+      for (let i = 0; i < rawSourceMap.sourcemap.sources.length; i++) {
+        const originalPath = rawSourceMap.sourcemap.sources[i]
+        const resolvedPath = this._rewritePath(sourceRoot, originalPath);
 
         let originalRawSource
         // If the source map has inline source content then it should be here
         // so use this inline one instead of trying to read the file off disk
         // Not sure what it means to have an array of more than 1 here so just ignore it
         // since we wouldn't know how to handle it
-        if (this.sources.sourceMap && this.sources.sourceMap.sourcemap && this.sources.sourceMap.sourcemap.sourcesContent && this.sources.sourceMap.sourcemap.sourcesContent.length === 1) {
-          originalRawSource = this.sources.sourceMap.sourcemap.sourcesContent[0]
+        if (this.sources.sourceMap && this.sources.sourceMap.sourcemap && this.sources.sourceMap.sourcemap.sourcesContent[i]) {
+          originalRawSource = this.sources.sourceMap.sourcemap.sourcesContent[i]
         } else if (this.sources.originalSource) {
           originalRawSource = this.sources.originalSource
         } else {
-          originalRawSource = await readFile(this.path, 'utf8')
+          originalRawSource = await readFile(resolvedPath, 'utf8')
         }
 
-        this.source = new CovSource(originalRawSource, this.wrapperLength)
-        this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+        this._makeFileCoverage(originalPath, new CovSource(originalRawSource, this.wrapperLength), resolvedPath)
       }
+      this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
     } else {
-      this.source = new CovSource(rawSource, this.wrapperLength)
+      this._makeFileCoverage(this.path, new CovSource(rawSource, this.wrapperLength))
     }
   }
 
-  _rewritePath (rawSourceMap) {
-    const sourceRoot = rawSourceMap.sourcemap.sourceRoot ? rawSourceMap.sourcemap.sourceRoot.replace('file://', '') : ''
-    const sourcePath = rawSourceMap.sourcemap.sources[0].replace('file://', '')
+  _makeFileCoverage(path, source, resolvedPath = path) {
+    if (!source) {
+      throw new Error('no source passed');
+    }
+
+    this.files[path] = {
+      branches: [],
+      functions: [],
+      source,
+      path,
+      resolvedPath,
+    };
+  }
+
+  _rewritePath(sourceRoot, sourcePath) {
+    sourceRoot = sourceRoot ? sourceRoot.replace('file://', '') : ''
+    sourcePath = sourcePath.replace('file://', '')
+
     const candidatePath = join(sourceRoot, sourcePath)
 
     if (isAbsolute(candidatePath)) {
-      this.path = candidatePath
+      return candidatePath
     } else {
-      this.path = resolve(dirname(this.path), sourcePath)
+      return resolve(dirname(this.path), sourcePath)
     }
   }
 
-  applyCoverage (blocks) {
+  applyCoverage(blocks) {
     blocks.forEach(block => {
       block.ranges.forEach((range, i) => {
-        const {
-          startCol,
-          endCol
-        } = this._maybeRemapStartColEndCol(range)
-        const lines = this.source.lines.filter(line => {
-          // Upstream tooling can provide a block with the functionName
-          // (empty-report), this will result in a report that has all
-          // lines zeroed out.
-          if (block.functionName === '(empty-report)') {
-            line.count = 0
-            return true
+        const subRanges = this._maybeRemapStartColEndCol(range)
+        subRanges.forEach((subRange) => {
+          const {
+            startCol,
+            endCol,
+            fileInfo
+          } = subRange;
+          if (!fileInfo) {
+            return;
           }
-          return startCol <= line.endCol && endCol >= line.startCol
-        })
-        const startLineInstance = lines[0]
-        const endLineInstance = lines[lines.length - 1]
+          const { source, functions, branches } = fileInfo;
+          const lines = source.lines.filter(line => {
+            // Upstream tooling can provide a block with the functionName
+            // (empty-report), this will result in a report that has all
+            // lines zeroed out.
+            if (block.functionName === '(empty-report)') {
+              line.count = 0
+              return true
+            }
+            return startCol <= line.endCol && endCol >= line.startCol
+          })
+          const startLineInstance = lines[0]
+          const endLineInstance = lines[lines.length - 1]
 
-        if (block.isBlockCoverage && lines.length) {
-          // record branches.
-          this.branches.push(new CovBranch(
-            startLineInstance.line,
-            startCol - startLineInstance.startCol,
-            endLineInstance.line,
-            endCol - endLineInstance.startCol,
-            range.count
-          ))
+          if (block.isBlockCoverage && lines.length) {
+            // record branches.
+            branches.push(new CovBranch(
+              startLineInstance.line,
+              startCol - startLineInstance.startCol,
+              endLineInstance.line,
+              endCol - endLineInstance.startCol,
+              range.count
+            ))
 
-          // if block-level granularity is enabled, we we still create a single
-          // CovFunction tracking object for each set of ranges.
-          if (block.functionName && i === 0) {
-            this.functions.push(new CovFunction(
+            // if block-level granularity is enabled, we we still create a single
+            // CovFunction tracking object for each set of ranges.
+            if (block.functionName && i === 0) {
+              functions.push(new CovFunction(
+                block.functionName,
+                startLineInstance.line,
+                startCol - startLineInstance.startCol,
+                endLineInstance.line,
+                endCol - endLineInstance.startCol,
+                range.count
+              ))
+            }
+          } else if (block.functionName && lines.length) {
+            // record functions.
+            functions.push(new CovFunction(
               block.functionName,
               startLineInstance.line,
               startCol - startLineInstance.startCol,
@@ -125,114 +155,140 @@ module.exports = class V8ToIstanbul {
               range.count
             ))
           }
-        } else if (block.functionName && lines.length) {
-          // record functions.
-          this.functions.push(new CovFunction(
-            block.functionName,
-            startLineInstance.line,
-            startCol - startLineInstance.startCol,
-            endLineInstance.line,
-            endCol - endLineInstance.startCol,
-            range.count
-          ))
-        }
 
-        // record the lines (we record these as statements, such that we're
-        // compatible with Istanbul 2.0).
-        lines.forEach(line => {
-          // make sure branch spans entire line; don't record 'goodbye'
-          // branch in `const foo = true ? 'hello' : 'goodbye'` as a
-          // 0 for line coverage.
-          //
-          // All lines start out with coverage of 1, and are later set to 0
-          // if they are not invoked; line.ignore prevents a line from being
-          // set to 0, and is set if the special comment /* c8 ignore next */
-          // is used.
-          if (startCol <= line.startCol && endCol >= line.endCol && !line.ignore) {
-            line.count = range.count
-          }
+          // record the lines (we record these as statements, such that we're
+          // compatible with Istanbul 2.0).
+          lines.forEach(line => {
+            // make sure branch spans entire line; don't record 'goodbye'
+            // branch in `const foo = true ? 'hello' : 'goodbye'` as a
+            // 0 for line coverage.
+            //
+            // All lines start out with coverage of 1, and are later set to 0
+            // if they are not invoked; line.ignore prevents a line from being
+            // set to 0, and is set if the special comment /* c8 ignore next */
+            // is used.
+            if (startCol <= line.startCol && endCol >= line.endCol && !line.ignore) {
+              line.count = range.count
+            }
+          })
         })
       })
     })
   }
 
-  _maybeRemapStartColEndCol (range) {
-    let startCol = Math.max(0, range.startOffset - this.source.wrapperLength)
-    let endCol = Math.min(this.source.eof, range.endOffset - this.source.wrapperLength)
-
+  _maybeRemapStartColEndCol(range) {
     if (this.sourceMap) {
-      startCol = Math.max(0, range.startOffset - this.sourceTranspiled.wrapperLength)
-      endCol = Math.min(this.sourceTranspiled.eof, range.endOffset - this.sourceTranspiled.wrapperLength)
+      const startCol = Math.max(0, range.startOffset - this.sourceTranspiled.wrapperLength)
+      const endCol = Math.min(this.sourceTranspiled.eof, range.endOffset - this.sourceTranspiled.wrapperLength)
 
-      const { startLine, relStartCol, endLine, relEndCol } = this.sourceTranspiled.offsetToOriginalRelative(
+      const locs = this.sourceTranspiled.offsetToOriginalRelative(
         this.sourceMap,
         startCol,
         endCol
-      )
+      );
 
-      // next we convert these relative positions back to absolute positions
-      // in the original source (which is the format expected in the next step).
-      startCol = this.source.relativeToOffset(startLine, relStartCol)
-      endCol = this.source.relativeToOffset(endLine, relEndCol)
+      return locs.map((loc) => {
+        const { startLine, relStartCol, endLine, relEndCol, sourceFile } = loc;
+
+        const fileInfo = this.files[sourceFile];
+
+        if (!fileInfo) {
+          console.log('did not find', sourceFile)
+          return {};
+        }
+
+        if (fileInfo.resolvedPath.indexOf('.tsx') >= 0) {
+          //console.log('-------------')
+          //console.log(fileInfo.resolvedPath)
+          //console.log(range)
+          //console.log({ startLine, relStartCol, endLine, relEndCol });
+        }
+
+        // next we convert these relative positions back to absolute positions
+        // in the original source (which is the format expected in the next step).
+        const startCol = fileInfo.source.relativeToOffset(startLine, relStartCol)
+        const endCol = fileInfo.source.relativeToOffset(endLine, relEndCol)
+
+        if (fileInfo.resolvedPath.indexOf('tsx') >= 0) {
+          // console.log({ startCol, endCol });
+        }
+
+        return {
+          fileInfo,
+          startCol,
+          endCol
+        }
+      });
     }
 
-    return {
+    const fileInfo = this.files[this.path];
+    const startCol = Math.max(0, range.startOffset - fileInfo.source.wrapperLength)
+    const endCol = Math.min(fileInfo.source.eof, range.endOffset - fileInfo.source.wrapperLength)
+
+    return [{
+      fileInfo,
       startCol,
       endCol
-    }
+    }]
   }
 
-  toIstanbul () {
-    const istanbulInner = Object.assign(
-      { path: this.path },
-      this._statementsToIstanbul(),
-      this._branchesToIstanbul(),
-      this._functionsToIstanbul()
-    )
+  toIstanbul() {
+
     const istanbulOuter = {}
-    istanbulOuter[this.path] = istanbulInner
+    Object.keys(this.files).forEach((file) => {
+
+      const { resolvedPath, source, branches, functions } = this.files[file];
+
+      const istanbulInner = Object.assign(
+        { path: resolvedPath },
+        this._statementsToIstanbul(source),
+        this._branchesToIstanbul(source, branches),
+        this._functionsToIstanbul(source, functions)
+      )
+      istanbulOuter[resolvedPath] = istanbulInner
+    });
     return istanbulOuter
   }
 
-  _statementsToIstanbul () {
+  _statementsToIstanbul(source) {
     const statements = {
       statementMap: {},
       s: {}
     }
-    this.source.lines.forEach((line, index) => {
+    source.lines.forEach((line, index) => {
       statements.statementMap[`${index}`] = line.toIstanbul()
       statements.s[`${index}`] = line.count
     })
     return statements
   }
 
-  _branchesToIstanbul () {
-    const branches = {
+  _branchesToIstanbul(source, branches) {
+    const iBranches = {
       branchMap: {},
       b: {}
     }
-    this.branches.forEach((branch, index) => {
-      const ignore = this.source.lines[branch.startLine - 1].ignore
-      branches.branchMap[`${index}`] = branch.toIstanbul()
-      branches.b[`${index}`] = [ignore ? 1 : branch.count]
+    branches.forEach((branch, index) => {
+      const ignore = source.lines[branch.startLine - 1].ignore
+      iBranches.branchMap[`${index}`] = branch.toIstanbul()
+      iBranches.b[`${index}`] = [ignore ? 1 : branch.count]
     })
-    return branches
+    return iBranches
   }
 
-  _functionsToIstanbul () {
-    const functions = {
+  _functionsToIstanbul(source, functions) {
+    const iFunctions = {
       fnMap: {},
       f: {}
     }
-    this.functions.forEach((fn, index) => {
-      const ignore = this.source.lines[fn.startLine - 1].ignore
-      functions.fnMap[`${index}`] = fn.toIstanbul()
-      functions.f[`${index}`] = ignore ? 1 : fn.count
+    functions.forEach((fn, index) => {
+      const ignore = source.lines[fn.startLine - 1].ignore
+      iFunctions.fnMap[`${index}`] = fn.toIstanbul()
+      iFunctions.f[`${index}`] = ignore ? 1 : fn.count
     })
-    return functions
+    return iFunctions
   }
 }
 
-function parsePath (scriptPath) {
+function parsePath(scriptPath) {
   return scriptPath.replace('file://', '')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "v8-to-istanbul",
-  "version": "4.0.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -18,7 +18,7 @@ describe('V8ToIstanbul', async () => {
         require.resolve('./fixtures/scripts/functions.js')
       )
       await v8ToIstanbul.load()
-      v8ToIstanbul.source.lines.length.should.equal(48)
+      v8ToIstanbul.files[v8ToIstanbul.path].source.lines.length.should.equal(48)
       v8ToIstanbul.wrapperLength.should.equal(0) // common-js header.
     })
 
@@ -28,7 +28,7 @@ describe('V8ToIstanbul', async () => {
         0
       )
       await v8ToIstanbul.load()
-      v8ToIstanbul.source.lines.length.should.equal(48)
+      v8ToIstanbul.files[v8ToIstanbul.path].lines.length.should.equal(48)
       v8ToIstanbul.wrapperLength.should.equal(0) // ESM header.
     })
 


### PR DESCRIPTION
This code seems to work on the repo I am trying to get it working on - that has typescript and then is compiled with webpack.

It would be cool to see if my changes produce better maps with people currently using this package.

- [x] Formatting - there are mistakes ~- its a bit of a nightmare because there doesn't appear to be any automated formatting ie either prettier or eslint. It would make my life easier to put that in!~ mostly fixed
- [ ] Tests - many of the tests assume implementation details so these fail
- [x] Performance - ~I believe this is significantly less performant than the current version, because it doesn't assume that a chrome range start maps to the start in one file and the chrome range map end is the same as the end in another. In my project I found lots of occasions where this wasn't true, so I assume this will make single source map coverage mapping better too. I think we could use sourceMap.eachMapping instead of lots of queries and it would make things quicker. Its a shame that function doesn't allow you to set a start and end position, but probably even an immediate return for mappings outside the current range would work or else use it to populate our own sourcemap consumer that can get the nextOriginalMapping and endOfOriginalMapping etc.~ The new implementation is very fast. It could be a little faster by passing in an option to ignore files so that unnecessary computation isn't done on them
