### PR TITLE
fix: handle sourcemap `sources` emtpy edge case

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -73,7 +73,7 @@ module.exports = class V8ToIstanbul {
 
   _rewritePath (rawSourceMap) {
     const sourceRoot = rawSourceMap.sourcemap.sourceRoot ? rawSourceMap.sourcemap.sourceRoot.replace('file://', '') : ''
-    const sourcePath = rawSourceMap.sourcemap.sources[0].replace('file://', '')
+    const sourcePath = rawSourceMap.sourcemap.sources.length >= 1 ? rawSourceMap.sourcemap.sources[0].replace('file://', '') : rawSourceMap.sourcemap.file
     const candidatePath = join(sourceRoot, sourcePath)
 
     if (isAbsolute(candidatePath)) {

--- a/test/fixtures/scripts/empty.compiled.js
+++ b/test/fixtures/scripts/empty.compiled.js
@@ -1,0 +1,3 @@
+
+
+//# sourceMappingURL=empty.compiled.js.map

--- a/test/fixtures/scripts/empty.compiled.js.map
+++ b/test/fixtures/scripts/empty.compiled.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":[],"names":[],"mappings":"","file":"empty.compiled.js"}

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -1,5 +1,4 @@
-/* global describe, it */
-
+/* global describe, it, beforeEach, afterEach */
 const { readdirSync, lstatSync, writeFileSync, readFileSync } = require('fs')
 const path = require('path')
 const runFixture = require('./utils/run-fixture')
@@ -88,6 +87,23 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       // if the source is transpiled and since we didn't inline the source map into the transpiled source file
       // that means it was bale to access the content via the provided sources object
       v8ToIstanbul.sourceTranspiled.should.not.be.undefined()
+    })
+  })
+  describe('source map format edge cases', () => {
+    let consoleWarn
+    beforeEach(() => {
+      consoleWarn = console.warn
+      console.warn = () => { throw new Error('Test should not invoke console.warn') }
+    })
+    afterEach(() => {
+      console.warn = consoleWarn
+    })
+    it('should handle empty sources in a sourcemap', async () => {
+      const v8ToIstanbul = new V8ToIstanbul(
+        `file://${require.resolve('./fixtures/scripts/empty.compiled.js')}`,
+        0
+      )
+      await v8ToIstanbul.load()
     })
   })
 


### PR DESCRIPTION
For source maps, the sources property can potentially be an empty array if mappings
doesn't provide any information about its origin. For example if you compile an empty
js file with babel, a valid sourcemap can be created with `[]` for `sources`. Here
we add a fallback to `file` in this case and adds a fixture to test for it.

The new test fixtures `empty.js`, `emtpy.compiled.js` and `empty.compiled.js.map`
simulate this scenario for a unit test.

This is bug 1 from the previous PR. To see the problem in action, comment out the fix line in `lib/v8-to-istanbul` and you will see the crash that happens when we try to load a sourcemap like this. 