### PR TITLE
fix: handle relative sourceRoots in source map files

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -79,7 +79,7 @@ module.exports = class V8ToIstanbul {
     if (isAbsolute(candidatePath)) {
       this.path = candidatePath
     } else {
-      this.path = resolve(dirname(this.path), sourcePath)
+      this.path = resolve(dirname(this.path), candidatePath)
     }
   }
 

--- a/test/fixtures/scripts/relative-source-root.compiled.js
+++ b/test/fixtures/scripts/relative-source-root.compiled.js
@@ -1,0 +1,3 @@
+
+
+//# sourceMappingURL=relative-source-root.compiled.js.map

--- a/test/fixtures/scripts/relative-source-root.compiled.js.map
+++ b/test/fixtures/scripts/relative-source-root.compiled.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["one-up/relative-source-root.js"],"names":[],"mappings":"","file":"relative-source-root.compiled.js", "sourceRoot":"../" }

--- a/test/source.js
+++ b/test/source.js
@@ -32,6 +32,12 @@ describe('Source', () => {
       source.relativeToOffset(2, 50).should.equal(22)
       source.relativeToOffset(1, Infinity).should.equal(1)
     })
+
+    it('returns empty object for out of range params', () => {
+      const sourceRaw = ''
+      const source = new CovSource(sourceRaw, 0)
+      source.offsetToOriginalRelative(undefined, Infinity, Infinity).should.deepEqual({})
+    })
   })
 
   describe('ignore', () => {

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -136,6 +136,15 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       )
       await v8ToIstanbul.load()
     })
+
+    it('should handle relative sourceRoots correctly', async () => {
+      const v8ToIstanbul = new V8ToIstanbul(
+        `file://${require.resolve('./fixtures/scripts/relative-source-root.compiled.js')}`,
+        0
+      )
+      await v8ToIstanbul.load()
+      assert(v8ToIstanbul.path.includes('v8-to-istanbul/test/fixtures/one-up/relative-source-root.js'))
+    })
   })
 
   // execute JavaScript files in fixtures directory; these


### PR DESCRIPTION
Fixes the issue recorded in https://github.com/istanbuljs/v8-to-istanbul/issues/99

For the test case, you can run the new unit test on master as is and you can see the invalid source resolution. With the fix the path is correct.