### PR TITLE
fix: add missing type in TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,6 @@ declare class V8ToIstanbul {
   toIstanbul(): CoverageMapData
 }
 
-declare function v8ToIstanbul(scriptPath: string, wrapperLength?: number, sources?: Sources, excludePath?: (path) => boolean): V8ToIstanbul
+declare function v8ToIstanbul(scriptPath: string, wrapperLength?: number, sources?: Sources, excludePath?: (path: string) => boolean): V8ToIstanbul
 
 export = v8ToIstanbul


### PR DESCRIPTION
Upgrading to v5 gives a type error in Jest:
![image](https://user-images.githubusercontent.com/1404810/89428480-b7ce9480-d73c-11ea-8de1-a6695dada82b.png)
