### PR TITLE
feat: add support for 1:1 sourcesContent

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -63,6 +63,8 @@ module.exports = class V8ToIstanbul {
           originalRawSource = this.sources.sourceMap.sourcemap.sourcesContent[0]
         } else if (this.sources.originalSource) {
           originalRawSource = this.sources.originalSource
+        } else if (this.sourceMap.sourcesContent && this.sourceMap.sourcesContent[0]) {
+          originalRawSource = this.sourceMap.sourcesContent[0]
         } else {
           originalRawSource = await readFile(this.path, 'utf8')
         }


### PR DESCRIPTION
I have js files generated by tsc which have the source map with a `sourcesContent` property embedded as base64 data url. This fix makes `v8-to-istanbul` pick that up.