### PR TITLE
fix!: address off by one error processing branches

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -107,30 +107,21 @@ module.exports = class V8ToIstanbul {
             return true
           }
 
-          return startCol <= line.endCol && endCol >= line.startCol
+          return startCol < line.endCol && endCol >= line.startCol
         })
         const startLineInstance = lines[0]
         const endLineInstance = lines[lines.length - 1]
 
         if (block.isBlockCoverage && lines.length) {
-          // If the beginning and end lines that a branch references have
-          // been ignored, ignore the branch:
-          if (
-            (covSource.lines[startLineInstance.line] === undefined ||
-            covSource.lines[startLineInstance.line].ignore === false) &&
-            (covSource.lines[endLineInstance.line] === undefined ||
-            covSource.lines[endLineInstance.line].ignore === false)
-          ) {
-            this.branches[path] = this.branches[path] || []
-            // record branches.
-            this.branches[path].push(new CovBranch(
-              startLineInstance.line,
-              startCol - startLineInstance.startCol,
-              endLineInstance.line,
-              endCol - endLineInstance.startCol,
-              range.count
-            ))
-          }
+          this.branches[path] = this.branches[path] || []
+          // record branches.
+          this.branches[path].push(new CovBranch(
+            startLineInstance.line,
+            startCol - startLineInstance.startCol,
+            endLineInstance.line,
+            endCol - endLineInstance.startCol,
+            range.count
+          ))
 
           // if block-level granularity is enabled, we we still create a single
           // CovFunction tracking object for each set of ranges.

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -113,15 +113,24 @@ module.exports = class V8ToIstanbul {
         const endLineInstance = lines[lines.length - 1]
 
         if (block.isBlockCoverage && lines.length) {
-          this.branches[path] = this.branches[path] || []
-          // record branches.
-          this.branches[path].push(new CovBranch(
-            startLineInstance.line,
-            startCol - startLineInstance.startCol,
-            endLineInstance.line,
-            endCol - endLineInstance.startCol,
-            range.count
-          ))
+          // If the beginning and end lines that a branch references have
+          // been ignored, ignore the branch:
+          if (
+            (covSource.lines[startLineInstance.line] === undefined ||
+            covSource.lines[startLineInstance.line].ignore === false) &&
+            (covSource.lines[endLineInstance.line] === undefined ||
+            covSource.lines[endLineInstance.line].ignore === false)
+          ) {
+            this.branches[path] = this.branches[path] || []
+            // record branches.
+            this.branches[path].push(new CovBranch(
+              startLineInstance.line,
+              startCol - startLineInstance.startCol,
+              endLineInstance.line,
+              endCol - endLineInstance.startCol,
+              range.count
+            ))
+          }
 
           // if block-level granularity is enabled, we we still create a single
           // CovFunction tracking object for each set of ranges.

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -2038,26 +2038,26 @@ Object {
   },
   "branchMap": Object {
     "0": Object {
-      "line": 38,
+      "line": 31,
       "loc": Object {
         "end": Object {
-          "column": 4,
-          "line": 38,
+          "column": 10,
+          "line": 31,
         },
         "start": Object {
-          "column": 4,
-          "line": 38,
+          "column": 10,
+          "line": 31,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 4,
-            "line": 38,
+            "column": 10,
+            "line": 31,
           },
           "start": Object {
-            "column": 4,
-            "line": 38,
+            "column": 10,
+            "line": 31,
           },
         },
       ],
@@ -2194,26 +2194,26 @@ Object {
       "type": "branch",
     },
     "5": Object {
-      "line": 38,
+      "line": 31,
       "loc": Object {
         "end": Object {
-          "column": 4,
-          "line": 38,
+          "column": 10,
+          "line": 31,
         },
         "start": Object {
-          "column": 4,
-          "line": 38,
+          "column": 10,
+          "line": 31,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 4,
-            "line": 38,
+            "column": 10,
+            "line": 31,
           },
           "start": Object {
-            "column": 4,
-            "line": 38,
+            "column": 10,
+            "line": 31,
           },
         },
       ],
@@ -2379,13 +2379,6 @@ Object {
     "29": 1,
     "3": 1,
     "30": 1,
-    "31": 1,
-    "32": 1,
-    "33": 1,
-    "34": 1,
-    "35": 1,
-    "36": 1,
-    "37": 1,
     "4": 1,
     "5": 1,
     "6": 1,
@@ -2642,76 +2635,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 31,
-      },
-    },
-    "31": Object {
-      "end": Object {
-        "column": 0,
-        "line": 32,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 32,
-      },
-    },
-    "32": Object {
-      "end": Object {
-        "column": 15,
-        "line": 33,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 33,
-      },
-    },
-    "33": Object {
-      "end": Object {
-        "column": 14,
-        "line": 34,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 34,
-      },
-    },
-    "34": Object {
-      "end": Object {
-        "column": 22,
-        "line": 35,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 35,
-      },
-    },
-    "35": Object {
-      "end": Object {
-        "column": 28,
-        "line": 36,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 36,
-      },
-    },
-    "36": Object {
-      "end": Object {
-        "column": 1,
-        "line": 37,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 37,
-      },
-    },
-    "37": Object {
-      "end": Object {
-        "column": 4,
-        "line": 38,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 38,
       },
     },
     "4": Object {

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -12,7 +12,7 @@ Object {
       1,
     ],
     "1": Array [
-      1,
+      0,
     ],
     "2": Array [
       0,
@@ -32,14 +32,17 @@ Object {
     "7": Array [
       0,
     ],
+    "8": Array [
+      1,
+    ],
   },
   "branchMap": Object {
     "0": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
-          "column": 10,
-          "line": 31,
+          "column": 4,
+          "line": 38,
         },
         "start": Object {
           "column": 0,
@@ -49,8 +52,8 @@ Object {
       "locations": Array [
         Object {
           "end": Object {
-            "column": 10,
-            "line": 31,
+            "column": 4,
+            "line": 38,
           },
           "start": Object {
             "column": 0,
@@ -61,26 +64,26 @@ Object {
       "type": "branch",
     },
     "1": Object {
-      "line": 1,
+      "line": 2,
       "loc": Object {
         "end": Object {
-          "column": 10,
-          "line": 31,
+          "column": 18,
+          "line": 2,
         },
         "start": Object {
-          "column": 1,
-          "line": 1,
+          "column": 13,
+          "line": 2,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 10,
-            "line": 31,
+            "column": 18,
+            "line": 2,
           },
           "start": Object {
-            "column": 1,
-            "line": 1,
+            "column": 13,
+            "line": 2,
           },
         },
       ],
@@ -90,22 +93,22 @@ Object {
       "line": 5,
       "loc": Object {
         "end": Object {
-          "column": 28,
+          "column": 25,
           "line": 5,
         },
         "start": Object {
-          "column": 23,
+          "column": 16,
           "line": 5,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 28,
+            "column": 25,
             "line": 5,
           },
           "start": Object {
-            "column": 23,
+            "column": 16,
             "line": 5,
           },
         },
@@ -116,22 +119,22 @@ Object {
       "line": 8,
       "loc": Object {
         "end": Object {
-          "column": 29,
+          "column": 31,
           "line": 8,
         },
         "start": Object {
-          "column": 22,
+          "column": 26,
           "line": 8,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 29,
+            "column": 31,
             "line": 8,
           },
           "start": Object {
-            "column": 22,
+            "column": 26,
             "line": 8,
           },
         },
@@ -139,52 +142,52 @@ Object {
       "type": "branch",
     },
     "4": Object {
-      "line": 14,
+      "line": 11,
       "loc": Object {
         "end": Object {
-          "column": 4,
-          "line": 15,
+          "column": 1,
+          "line": 13,
         },
         "start": Object {
-          "column": 8,
-          "line": 14,
+          "column": 11,
+          "line": 11,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 4,
-            "line": 15,
+            "column": 1,
+            "line": 13,
           },
           "start": Object {
-            "column": 8,
-            "line": 14,
+            "column": 11,
+            "line": 11,
           },
         },
       ],
       "type": "branch",
     },
     "5": Object {
-      "line": 18,
+      "line": 31,
       "loc": Object {
         "end": Object {
-          "column": 21,
-          "line": 18,
+          "column": 10,
+          "line": 31,
         },
         "start": Object {
-          "column": 3,
-          "line": 18,
+          "column": 5,
+          "line": 31,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 21,
-            "line": 18,
+            "column": 10,
+            "line": 31,
           },
           "start": Object {
-            "column": 3,
-            "line": 18,
+            "column": 5,
+            "line": 31,
           },
         },
       ],
@@ -242,9 +245,36 @@ Object {
       ],
       "type": "branch",
     },
+    "8": Object {
+      "line": 33,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 37,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 33,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 1,
+            "line": 37,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 33,
+          },
+        },
+      ],
+      "type": "branch",
+    },
   },
   "f": Object {
     "0": 1,
+    "1": 1,
   },
   "fnMap": Object {
     "0": Object {
@@ -271,13 +301,37 @@ Object {
       },
       "name": "e",
     },
+    "1": Object {
+      "decl": Object {
+        "end": Object {
+          "column": 1,
+          "line": 37,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 33,
+        },
+      },
+      "line": 33,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 37,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 33,
+        },
+      },
+      "name": "fn",
+    },
   },
   "s": Object {
     "0": 1,
     "1": 1,
     "10": 1,
-    "11": 1,
-    "12": 1,
+    "11": 0,
+    "12": 0,
     "13": 1,
     "14": 1,
     "15": 1,
@@ -298,6 +352,13 @@ Object {
     "29": 1,
     "3": 1,
     "30": 1,
+    "31": 1,
+    "32": 1,
+    "33": 1,
+    "34": 1,
+    "35": 1,
+    "36": 1,
+    "37": 1,
     "4": 1,
     "5": 1,
     "6": 1,
@@ -554,6 +615,76 @@ Object {
       "start": Object {
         "column": 0,
         "line": 31,
+      },
+    },
+    "31": Object {
+      "end": Object {
+        "column": 0,
+        "line": 32,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 32,
+      },
+    },
+    "32": Object {
+      "end": Object {
+        "column": 15,
+        "line": 33,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 33,
+      },
+    },
+    "33": Object {
+      "end": Object {
+        "column": 14,
+        "line": 34,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 34,
+      },
+    },
+    "34": Object {
+      "end": Object {
+        "column": 22,
+        "line": 35,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 35,
+      },
+    },
+    "35": Object {
+      "end": Object {
+        "column": 28,
+        "line": 36,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 36,
+      },
+    },
+    "36": Object {
+      "end": Object {
+        "column": 1,
+        "line": 37,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 37,
+      },
+    },
+    "37": Object {
+      "end": Object {
+        "column": 4,
+        "line": 38,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 38,
       },
     },
     "4": Object {
@@ -1907,26 +2038,26 @@ Object {
   },
   "branchMap": Object {
     "0": Object {
-      "line": 31,
+      "line": 38,
       "loc": Object {
         "end": Object {
-          "column": 10,
-          "line": 31,
+          "column": 4,
+          "line": 38,
         },
         "start": Object {
-          "column": 10,
-          "line": 31,
+          "column": 4,
+          "line": 38,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 10,
-            "line": 31,
+            "column": 4,
+            "line": 38,
           },
           "start": Object {
-            "column": 10,
-            "line": 31,
+            "column": 4,
+            "line": 38,
           },
         },
       ],
@@ -2063,26 +2194,26 @@ Object {
       "type": "branch",
     },
     "5": Object {
-      "line": 31,
+      "line": 38,
       "loc": Object {
         "end": Object {
-          "column": 10,
-          "line": 31,
+          "column": 4,
+          "line": 38,
         },
         "start": Object {
-          "column": 10,
-          "line": 31,
+          "column": 4,
+          "line": 38,
         },
       },
       "locations": Array [
         Object {
           "end": Object {
-            "column": 10,
-            "line": 31,
+            "column": 4,
+            "line": 38,
           },
           "start": Object {
-            "column": 10,
-            "line": 31,
+            "column": 4,
+            "line": 38,
           },
         },
       ],
@@ -2248,6 +2379,13 @@ Object {
     "29": 1,
     "3": 1,
     "30": 1,
+    "31": 1,
+    "32": 1,
+    "33": 1,
+    "34": 1,
+    "35": 1,
+    "36": 1,
+    "37": 1,
     "4": 1,
     "5": 1,
     "6": 1,
@@ -2504,6 +2642,76 @@ Object {
       "start": Object {
         "column": 0,
         "line": 31,
+      },
+    },
+    "31": Object {
+      "end": Object {
+        "column": 0,
+        "line": 32,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 32,
+      },
+    },
+    "32": Object {
+      "end": Object {
+        "column": 15,
+        "line": 33,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 33,
+      },
+    },
+    "33": Object {
+      "end": Object {
+        "column": 14,
+        "line": 34,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 34,
+      },
+    },
+    "34": Object {
+      "end": Object {
+        "column": 22,
+        "line": 35,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 35,
+      },
+    },
+    "35": Object {
+      "end": Object {
+        "column": 28,
+        "line": 36,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 36,
+      },
+    },
+    "36": Object {
+      "end": Object {
+        "column": 1,
+        "line": 37,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 37,
+      },
+    },
+    "37": Object {
+      "end": Object {
+        "column": 4,
+        "line": 38,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 38,
       },
     },
     "4": Object {

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -35,6 +35,9 @@ Object {
     "8": Array [
       1,
     ],
+    "9": Array [
+      1,
+    ],
   },
   "branchMap": Object {
     "0": Object {
@@ -266,6 +269,32 @@ Object {
           "start": Object {
             "column": 0,
             "line": 33,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "9": Object {
+      "line": 35,
+      "loc": Object {
+        "end": Object {
+          "column": 0,
+          "line": 37,
+        },
+        "start": Object {
+          "column": -1,
+          "line": 35,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 0,
+            "line": 37,
+          },
+          "start": Object {
+            "column": -1,
+            "line": 35,
           },
         },
       ],
@@ -1850,15 +1879,15 @@ Object {
   },
   "branchMap": Object {
     "0": Object {
-      "line": 1,
+      "line": 2,
       "loc": Object {
         "end": Object {
           "column": 7,
           "line": 8,
         },
         "start": Object {
-          "column": 19,
-          "line": 1,
+          "column": -1,
+          "line": 2,
         },
       },
       "locations": Array [
@@ -1868,8 +1897,8 @@ Object {
             "line": 8,
           },
           "start": Object {
-            "column": 19,
-            "line": 1,
+            "column": -1,
+            "line": 2,
           },
         },
       ],
@@ -2003,12 +2032,9 @@ exports['test/v8-to-istanbul.js TAP > must match source-map and minified source 
 Object {
   "b": Object {
     "0": Array [
-      1,
-    ],
-    "1": Array [
       0,
     ],
-    "10": Array [
+    "1": Array [
       0,
     ],
     "2": Array [
@@ -2018,52 +2044,23 @@ Object {
       0,
     ],
     "4": Array [
-      0,
+      1,
     ],
     "5": Array [
       0,
     ],
     "6": Array [
-      1,
+      0,
     ],
     "7": Array [
-      0,
+      1,
     ],
     "8": Array [
       0,
     ],
-    "9": Array [
-      1,
-    ],
   },
   "branchMap": Object {
     "0": Object {
-      "line": 31,
-      "loc": Object {
-        "end": Object {
-          "column": 10,
-          "line": 31,
-        },
-        "start": Object {
-          "column": 10,
-          "line": 31,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 10,
-            "line": 31,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 31,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "1": Object {
       "line": 5,
       "loc": Object {
         "end": Object {
@@ -2089,33 +2086,7 @@ Object {
       ],
       "type": "branch",
     },
-    "10": Object {
-      "line": 29,
-      "loc": Object {
-        "end": Object {
-          "column": 10,
-          "line": 30,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 29,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 10,
-            "line": 30,
-          },
-          "start": Object {
-            "column": 0,
-            "line": 29,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "2": Object {
+    "1": Object {
       "line": 8,
       "loc": Object {
         "end": Object {
@@ -2141,7 +2112,7 @@ Object {
       ],
       "type": "branch",
     },
-    "3": Object {
+    "2": Object {
       "line": 11,
       "loc": Object {
         "end": Object {
@@ -2167,7 +2138,7 @@ Object {
       ],
       "type": "branch",
     },
-    "4": Object {
+    "3": Object {
       "line": 14,
       "loc": Object {
         "end": Object {
@@ -2193,33 +2164,7 @@ Object {
       ],
       "type": "branch",
     },
-    "5": Object {
-      "line": 31,
-      "loc": Object {
-        "end": Object {
-          "column": 10,
-          "line": 31,
-        },
-        "start": Object {
-          "column": 10,
-          "line": 31,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 10,
-            "line": 31,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 31,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "6": Object {
+    "4": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
@@ -2245,7 +2190,7 @@ Object {
       ],
       "type": "branch",
     },
-    "7": Object {
+    "5": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
@@ -2271,7 +2216,7 @@ Object {
       ],
       "type": "branch",
     },
-    "8": Object {
+    "6": Object {
       "line": 2,
       "loc": Object {
         "end": Object {
@@ -2297,7 +2242,7 @@ Object {
       ],
       "type": "branch",
     },
-    "9": Object {
+    "7": Object {
       "line": 20,
       "loc": Object {
         "end": Object {
@@ -2318,6 +2263,32 @@ Object {
           "start": Object {
             "column": 12,
             "line": 20,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "8": Object {
+      "line": 29,
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 29,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 10,
+            "line": 30,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 29,
           },
         },
       ],

--- a/test/fixtures/branches.js
+++ b/test/fixtures/branches.js
@@ -9,43 +9,32 @@ module.exports = {
         "ranges": [
           {
             "startOffset": 0,
-            "endOffset": 520,
-            "count": 1
-          }
-        ],
-        "isBlockCoverage": true
-      },
-      {
-        "functionName": "",
-        "ranges": [
-          {
-            "startOffset": 1,
-            "endOffset": 518,
+            "endOffset": 545,
             "count": 1
           },
           {
-            "startOffset": 102,
-            "endOffset": 107,
+            "startOffset": 40,
+            "endOffset": 45,
             "count": 0
           },
           {
-            "startOffset": 159,
-            "endOffset": 166,
+            "startOffset": 95,
+            "endOffset": 104,
             "count": 0
           },
           {
-            "startOffset": 225,
-            "endOffset": 230,
+            "startOffset": 163,
+            "endOffset": 168,
             "count": 0
           },
           {
-            "startOffset": 260,
-            "endOffset": 278,
+            "startOffset": 198,
+            "endOffset": 216,
             "count": 0
           },
           {
-            "startOffset": 510,
-            "endOffset": 515,
+            "startOffset": 448,
+            "endOffset": 453,
             "count": 0
           }
         ],
@@ -62,6 +51,22 @@ module.exports = {
           {
             "startOffset": 411,
             "endOffset": 433,
+            "count": 0
+          }
+        ],
+        "isBlockCoverage": true
+      },
+      {
+        "functionName": "fn",
+        "ranges": [
+          {
+            "startOffset": 455,
+            "endOffset": 539,
+            "count": 1
+          },
+          {
+            "startOffset": 485,
+            "endOffset": 538,
             "count": 0
           }
         ],

--- a/test/fixtures/scripts/branches.js
+++ b/test/fixtures/scripts/branches.js
@@ -29,3 +29,10 @@ e()
 // binary operation that spans multiple lines.
 const g = 99 &&
   33 || 13
+
+function fn() {
+  return true;
+  /* c8 ignore next */
+  console.log('never runs');
+}
+fn()


### PR DESCRIPTION
Due to an off by one error when determining blocks in v8, the first character of a block range is sometimes the `\n` from the prior line:

In the example:

```js
function fn() {
  return true;
  /* c8 ignore next */
  console.log('never runs');
}

fn();
```

One of the blocks is characters 30 - 83, or:

```
\n  /* c8 ignore next */\n  console.log('never runs');\n
```

It should not be possible for a conditional block to begin with a single character, so I believe we can address this problem by making the logic that calculates branches exclusive vs., inclusive, when it overlaps with the prior line.

Refs: https://github.com/bcoe/c8/issues/254