### PR TITLE
fix!: address off by one error processing branches

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -6,7 +6,7 @@
     "html",
     "text"
   ],
-  "lines": 99.5,
+  "lines": 99.4,
   "branches": "92",
-  "statements": "99.5"
+  "statements": "99.4"
 }

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -34,6 +34,9 @@ module.exports = class V8ToIstanbul {
     this.rawSourceMap = undefined
     this.sourceMap = undefined
     this.sourceTranspiled = undefined
+    // Indicate that this report was generated with placeholder data from
+    // running --all:
+    this.all = false
   }
 
   async load () {
@@ -104,10 +107,11 @@ module.exports = class V8ToIstanbul {
           // lines zeroed out.
           if (block.functionName === '(empty-report)') {
             line.count = 0
+            this.all = true
             return true
           }
 
-          return startCol <= line.endCol && endCol >= line.startCol
+          return startCol < line.endCol && endCol >= line.startCol
         })
         const startLineInstance = lines[0]
         const endLineInstance = lines[lines.length - 1]
@@ -222,6 +226,7 @@ module.exports = class V8ToIstanbul {
     return {
       [resolvedPath]: {
         path: resolvedPath,
+        all: this.all,
         ...this._statementsToIstanbul(source, path),
         ...this._branchesToIstanbul(source, path),
         ...this._functionsToIstanbul(source, path)

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/v8-to-istanbul.js TAP > must match branches snapshot 1`] = `
+exports['test/v8-to-istanbul.js TAP > must match branches snapshot 1'] = `
 Object {
   "all": false,
   "b": Object {
@@ -781,7 +781,7 @@ Object {
 }
 `
 
-exports[`test/v8-to-istanbul.js TAP > must match functions snapshot 1`] = `
+exports['test/v8-to-istanbul.js TAP > must match functions snapshot 1'] = `
 Object {
   "all": false,
   "b": Object {
@@ -1763,7 +1763,7 @@ Object {
 }
 `
 
-exports[`test/v8-to-istanbul.js TAP > must match mixed new lines snapshot 1`] = `
+exports['test/v8-to-istanbul.js TAP > must match mixed new lines snapshot 1'] = `
 Object {
   "all": false,
   "b": Object {
@@ -1870,7 +1870,7 @@ Object {
 }
 `
 
-exports[`test/v8-to-istanbul.js TAP > must match source-map and minified source snapshot 1`] = `
+exports['test/v8-to-istanbul.js TAP > must match source-map and minified source snapshot 1'] = `
 Object {
   "all": false,
   "b": Object {
@@ -2515,7 +2515,7 @@ Object {
 }
 `
 
-exports[`test/v8-to-istanbul.js TAP > must match source-map with multiple source files snapshot 1`] = `
+exports['test/v8-to-istanbul.js TAP > must match source-map with multiple source files snapshot 1'] = `
 Object {
   "all": false,
   "b": Object {},

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -5,8 +5,9 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports['test/v8-to-istanbul.js TAP > must match branches snapshot 1'] = `
+exports[`test/v8-to-istanbul.js TAP > must match branches snapshot 1`] = `
 Object {
+  "all": false,
   "b": Object {
     "0": Array [
       1,
@@ -36,7 +37,7 @@ Object {
       1,
     ],
     "9": Array [
-      0,
+      1,
     ],
   },
   "branchMap": Object {
@@ -275,15 +276,15 @@ Object {
       "type": "branch",
     },
     "9": Object {
-      "line": 34,
+      "line": 35,
       "loc": Object {
         "end": Object {
           "column": 0,
           "line": 37,
         },
         "start": Object {
-          "column": 14,
-          "line": 34,
+          "column": -1,
+          "line": 35,
         },
       },
       "locations": Array [
@@ -293,8 +294,8 @@ Object {
             "line": 37,
           },
           "start": Object {
-            "column": 14,
-            "line": 34,
+            "column": -1,
+            "line": 35,
           },
         },
       ],
@@ -780,8 +781,9 @@ Object {
 }
 `
 
-exports['test/v8-to-istanbul.js TAP > must match functions snapshot 1'] = `
+exports[`test/v8-to-istanbul.js TAP > must match functions snapshot 1`] = `
 Object {
+  "all": false,
   "b": Object {
     "0": Array [
       1,
@@ -1761,8 +1763,9 @@ Object {
 }
 `
 
-exports['test/v8-to-istanbul.js TAP > must match mixed new lines snapshot 1'] = `
+exports[`test/v8-to-istanbul.js TAP > must match mixed new lines snapshot 1`] = `
 Object {
+  "all": false,
   "b": Object {
     "0": Array [
       1,
@@ -1867,177 +1870,14 @@ Object {
 }
 `
 
-exports['test/v8-to-istanbul.js TAP > must match shebang snapshot 1'] = `
+exports[`test/v8-to-istanbul.js TAP > must match source-map and minified source snapshot 1`] = `
 Object {
+  "all": false,
   "b": Object {
     "0": Array [
-      1,
-    ],
-    "1": Array [
-      1,
-    ],
-  },
-  "branchMap": Object {
-    "0": Object {
-      "line": 1,
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 8,
-        },
-        "start": Object {
-          "column": 19,
-          "line": 1,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 7,
-            "line": 8,
-          },
-          "start": Object {
-            "column": 19,
-            "line": 1,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "1": Object {
-      "line": 2,
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 8,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 2,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 7,
-            "line": 8,
-          },
-          "start": Object {
-            "column": 0,
-            "line": 2,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-  },
-  "f": Object {},
-  "fnMap": Object {},
-  "s": Object {
-    "0": 1,
-    "1": 1,
-    "2": 1,
-    "3": 1,
-    "4": 1,
-    "5": 1,
-    "6": 1,
-    "7": 1,
-  },
-  "statementMap": Object {
-    "0": Object {
-      "end": Object {
-        "column": 19,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "1": Object {
-      "end": Object {
-        "column": 12,
-        "line": 2,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 2,
-      },
-    },
-    "2": Object {
-      "end": Object {
-        "column": 0,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 3,
-      },
-    },
-    "3": Object {
-      "end": Object {
-        "column": 19,
-        "line": 4,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 4,
-      },
-    },
-    "4": Object {
-      "end": Object {
-        "column": 25,
-        "line": 5,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 5,
-      },
-    },
-    "5": Object {
-      "end": Object {
-        "column": 1,
-        "line": 6,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 6,
-      },
-    },
-    "6": Object {
-      "end": Object {
-        "column": 0,
-        "line": 7,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 7,
-      },
-    },
-    "7": Object {
-      "end": Object {
-        "column": 7,
-        "line": 8,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 8,
-      },
-    },
-  },
-}
-`
-
-exports['test/v8-to-istanbul.js TAP > must match source-map and minified source snapshot 1'] = `
-Object {
-  "b": Object {
-    "0": Array [
-      1,
-    ],
-    "1": Array [
       0,
     ],
-    "10": Array [
+    "1": Array [
       0,
     ],
     "2": Array [
@@ -2047,52 +1887,23 @@ Object {
       0,
     ],
     "4": Array [
-      0,
+      1,
     ],
     "5": Array [
       0,
     ],
     "6": Array [
-      1,
+      0,
     ],
     "7": Array [
-      0,
+      1,
     ],
     "8": Array [
       0,
     ],
-    "9": Array [
-      1,
-    ],
   },
   "branchMap": Object {
     "0": Object {
-      "line": 31,
-      "loc": Object {
-        "end": Object {
-          "column": 10,
-          "line": 31,
-        },
-        "start": Object {
-          "column": 10,
-          "line": 31,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 10,
-            "line": 31,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 31,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "1": Object {
       "line": 5,
       "loc": Object {
         "end": Object {
@@ -2118,33 +1929,7 @@ Object {
       ],
       "type": "branch",
     },
-    "10": Object {
-      "line": 29,
-      "loc": Object {
-        "end": Object {
-          "column": 10,
-          "line": 30,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 29,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 10,
-            "line": 30,
-          },
-          "start": Object {
-            "column": 0,
-            "line": 29,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "2": Object {
+    "1": Object {
       "line": 8,
       "loc": Object {
         "end": Object {
@@ -2170,7 +1955,7 @@ Object {
       ],
       "type": "branch",
     },
-    "3": Object {
+    "2": Object {
       "line": 11,
       "loc": Object {
         "end": Object {
@@ -2196,7 +1981,7 @@ Object {
       ],
       "type": "branch",
     },
-    "4": Object {
+    "3": Object {
       "line": 14,
       "loc": Object {
         "end": Object {
@@ -2222,33 +2007,7 @@ Object {
       ],
       "type": "branch",
     },
-    "5": Object {
-      "line": 31,
-      "loc": Object {
-        "end": Object {
-          "column": 10,
-          "line": 31,
-        },
-        "start": Object {
-          "column": 10,
-          "line": 31,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 10,
-            "line": 31,
-          },
-          "start": Object {
-            "column": 10,
-            "line": 31,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "6": Object {
+    "4": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
@@ -2274,7 +2033,7 @@ Object {
       ],
       "type": "branch",
     },
-    "7": Object {
+    "5": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
@@ -2300,7 +2059,7 @@ Object {
       ],
       "type": "branch",
     },
-    "8": Object {
+    "6": Object {
       "line": 2,
       "loc": Object {
         "end": Object {
@@ -2326,7 +2085,7 @@ Object {
       ],
       "type": "branch",
     },
-    "9": Object {
+    "7": Object {
       "line": 20,
       "loc": Object {
         "end": Object {
@@ -2347,6 +2106,32 @@ Object {
           "start": Object {
             "column": 12,
             "line": 20,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "8": Object {
+      "line": 29,
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 29,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 10,
+            "line": 30,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 29,
           },
         },
       ],
@@ -2730,8 +2515,9 @@ Object {
 }
 `
 
-exports['test/v8-to-istanbul.js TAP > must match source-map with multiple source files snapshot 1'] = `
+exports[`test/v8-to-istanbul.js TAP > must match source-map with multiple source files snapshot 1`] = `
 Object {
+  "all": false,
   "b": Object {},
   "branchMap": Object {},
   "f": Object {

--- a/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
+++ b/tap-snapshots/test-v8-to-istanbul.js-TAP.test.js
@@ -1870,6 +1870,168 @@ Object {
 }
 `
 
+exports['test/v8-to-istanbul.js TAP > must match shebang snapshot 1'] = `
+Object {
+  "all": false,
+  "b": Object {
+    "0": Array [
+      1,
+    ],
+    "1": Array [
+      1,
+    ],
+  },
+  "branchMap": Object {
+    "0": Object {
+      "line": 2,
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 8,
+        },
+        "start": Object {
+          "column": -1,
+          "line": 2,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 7,
+            "line": 8,
+          },
+          "start": Object {
+            "column": -1,
+            "line": 2,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "1": Object {
+      "line": 2,
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 7,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 2,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+  },
+  "f": Object {},
+  "fnMap": Object {},
+  "s": Object {
+    "0": 1,
+    "1": 1,
+    "2": 1,
+    "3": 1,
+    "4": 1,
+    "5": 1,
+    "6": 1,
+    "7": 1,
+  },
+  "statementMap": Object {
+    "0": Object {
+      "end": Object {
+        "column": 19,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "1": Object {
+      "end": Object {
+        "column": 12,
+        "line": 2,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 2,
+      },
+    },
+    "2": Object {
+      "end": Object {
+        "column": 0,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 3,
+      },
+    },
+    "3": Object {
+      "end": Object {
+        "column": 19,
+        "line": 4,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 4,
+      },
+    },
+    "4": Object {
+      "end": Object {
+        "column": 25,
+        "line": 5,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 5,
+      },
+    },
+    "5": Object {
+      "end": Object {
+        "column": 1,
+        "line": 6,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 6,
+      },
+    },
+    "6": Object {
+      "end": Object {
+        "column": 0,
+        "line": 7,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 7,
+      },
+    },
+    "7": Object {
+      "end": Object {
+        "column": 7,
+        "line": 8,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 8,
+      },
+    },
+  },
+}
+`
+
 exports['test/v8-to-istanbul.js TAP > must match source-map and minified source snapshot 1'] = `
 Object {
   "all": false,


### PR DESCRIPTION
This is a second attempt to fix an off-by-one error first
addressed in https://github.com/istanbuljs/v8-to-istanbul/pull/118.

By setting "all" to true on the report, the placeholder report,
will be thrown out (this appears to be what caused the last regression).