### PR TITLE
feat: support comment c8 ignore start/stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ if (process.platform === 'win32') {
 }
 ```
 
+### ignoring all lines until told
+
+```js
+/* c8 ignore start */
+function dontMindMe() {
+  // ...
+}
+/* c8 ignore stop */
+```
+
 ### ignoring the same line as the comment
 
 ```js

--- a/test/source.js
+++ b/test/source.js
@@ -74,5 +74,29 @@ describe('Source', () => {
       source.lines[1].ignore.should.equal(true)
       source.lines[2].ignore.should.equal(false)
     })
+
+    it('ignores lines between start and stop', () => {
+      const sourceRaw = `
+      /* c8 ignore start */
+      function ignoreMe() {
+        // ...
+      }
+      /* c8 ignore stop */
+
+      function doNotIgnoreMe() {
+        // ...
+      }
+      `
+      const source = new CovSource(sourceRaw, 0)
+      source.lines[1].ignore.should.equal(true)
+      source.lines[2].ignore.should.equal(true)
+      source.lines[3].ignore.should.equal(true)
+      source.lines[4].ignore.should.equal(true)
+      source.lines[5].ignore.should.equal(true)
+      source.lines[6].ignore.should.equal(false)
+      source.lines[7].ignore.should.equal(false)
+      source.lines[8].ignore.should.equal(false)
+      source.lines[9].ignore.should.equal(false)
+    })
   })
 })


### PR DESCRIPTION
I implemented the idea I shared here: https://github.com/bcoe/c8/issues/271

```js
/* c8 ignore start */
function dontMindMe() {
  // ...
}
/* c8 ignore stop */
```

I refactored the function that parses for these `c8 ignore` comments to have no side effects; I also split up the "on its own line" case to be handled separately from the "ignore next n" case. My goal was to make the function and its usage more readable: let me know if I failed in that goal.