### PR TITLE
fix: use original source path if no sources

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -54,7 +54,7 @@ module.exports = class V8ToIstanbul {
         this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
       } else {
         const candidatePath = this.rawSourceMap.sourcemap.sources.length >= 1 ? this.rawSourceMap.sourcemap.sources[0] : this.rawSourceMap.sourcemap.file
-        this.path = this._resolveSource(this.rawSourceMap, candidatePath)
+        this.path = this._resolveSource(this.rawSourceMap, candidatePath || this.path)
         this.sourceMap = await new SourceMapConsumer(this.rawSourceMap.sourcemap)
 
         let originalRawSource


### PR DESCRIPTION
If a generated sourcemap has no sources / files (can happen from typescript type only imports) the originla source files path should be tried.

fixes #134 