### PR TITLE
fix: undefined line in branches and functions

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -257,7 +257,8 @@ module.exports = class V8ToIstanbul {
     }
     this.branches[path] = this.branches[path] || []
     this.branches[path].forEach((branch, index) => {
-      const ignore = source.lines[branch.startLine - 1].ignore
+      const srcLine = source.lines[branch.startLine - 1]
+      const ignore = srcLine === undefined ? true : srcLine.ignore
       branches.branchMap[`${index}`] = branch.toIstanbul()
       branches.b[`${index}`] = [ignore ? 1 : branch.count]
     })
@@ -271,7 +272,8 @@ module.exports = class V8ToIstanbul {
     }
     this.functions[path] = this.functions[path] || []
     this.functions[path].forEach((fn, index) => {
-      const ignore = source.lines[fn.startLine - 1].ignore
+      const srcLine = source.lines[fn.startLine - 1]
+      const ignore = srcLine === undefined ? true : srcLine.ignore
       functions.fnMap[`${index}`] = fn.toIstanbul()
       functions.f[`${index}`] = ignore ? 1 : fn.count
     })


### PR DESCRIPTION
When bundling this [file](https://github.com/browserify/node-util/blob/master/util.js) with esbuild and getting the v8 coverage with playwright `_branchesToIstanbul` and `_functionsToIstanbul` hanged.

These 2 functions actually should throw an error but it is swallowed for some reason.

This PR just ignores if it can't find the source line for the current branch or function.