### PR TITLE
feat: function to cleanup allocated resources after usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ converter.applyCoverage([
 // output coverage information in a form that can
 // be consumed by Istanbul.
 console.info(JSON.stringify(converter.toIstanbul()))
+
+// cleanup resources allocated in "load" (i.e. by the source-map dependency),
+// the converter may not be used anymore afterwards
+converter.destroy() 
 ```
 
 ## Ignoring Uncovered Lines

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ declare type Sources =
     }
 declare class V8ToIstanbul {
   load(): Promise<void>
+  destroy(): void
   applyCoverage(blocks: ReadonlyArray<Profiler.FunctionCoverage>): void
   toIstanbul(): CoverageMapData
 }

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -86,6 +86,7 @@ module.exports = class V8ToIstanbul {
   destroy () {
     if (this.sourceMap) {
       this.sourceMap.destroy()
+      this.sourceMap = undefined
     }
   }
 

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -83,6 +83,12 @@ module.exports = class V8ToIstanbul {
     }
   }
 
+  destroy () {
+    if (this.sourceMap) {
+      this.sourceMap.destroy()
+    }
+  }
+
   _resolveSource (rawSourceMap, sourcePath) {
     if (sourcePath.startsWith('file://')) {
       return fileURLToPath(sourcePath)

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -22,6 +22,8 @@ describe('V8ToIstanbul', async () => {
       v8ToIstanbul.covSources[0].source.lines.length.should.equal(48)
       v8ToIstanbul.covSources.length.should.equal(1)
       v8ToIstanbul.wrapperLength.should.equal(0) // common-js header.
+
+      v8ToIstanbul.destroy()
     })
 
     it('handles ESM style paths', async () => {
@@ -33,6 +35,8 @@ describe('V8ToIstanbul', async () => {
       v8ToIstanbul.covSources[0].source.lines.length.should.equal(48)
       v8ToIstanbul.covSources.length.should.equal(1)
       v8ToIstanbul.wrapperLength.should.equal(0) // ESM header.
+
+      v8ToIstanbul.destroy()
     })
 
     it('handles source maps with sourceRoot', async () => {
@@ -60,6 +64,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       await v8ToIstanbul.load()
 
       v8ToIstanbul.path.should.equal(absoluteSourceFilePath)
+
+      v8ToIstanbul.destroy()
     })
 
     it('handles sourceContent', async () => {
@@ -91,6 +97,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       // if the source is transpiled and since we didn't inline the source map into the transpiled source file
       // that means it was bale to access the content via the provided sources object
       v8ToIstanbul.sourceTranspiled.should.not.be.undefined()
+
+      v8ToIstanbul.destroy()
     })
 
     it('should clamp line source column >= 0', async () => {
@@ -121,6 +129,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
           endOffset: matchedNewLineChar + 10
         }]
       }])
+
+      v8ToIstanbul.destroy()
     })
 
     it('should exclude files when passing excludePath', async () => {
@@ -139,6 +149,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
         }]
       }])
       Object.keys(v8ToIstanbul.toIstanbul()).should.eql(['/src/index.ts', '/src/utils.ts'].map(path.normalize))
+
+      v8ToIstanbul.destroy()
     })
   })
 
@@ -157,6 +169,7 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
         0
       )
       await v8ToIstanbul.load()
+      v8ToIstanbul.destroy()
     })
 
     it('should handle relative sourceRoots correctly', async () => {
@@ -166,6 +179,7 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       )
       await v8ToIstanbul.load()
       assert(v8ToIstanbul.path.includes(path.normalize('v8-to-istanbul/test/fixtures/one-up/relative-source-root.js')))
+      v8ToIstanbul.destroy()
     })
 
     it('should handles source maps with multiple sources', async () => {
@@ -177,6 +191,8 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
 
       v8ToIstanbul.covSources.length.should.equal(3)
       Object.keys(v8ToIstanbul.toIstanbul()).should.eql(['/webpack/bootstrap', '/src/index.ts', '/src/utils.ts'].map(path.normalize))
+
+      v8ToIstanbul.destroy()
     })
   })
 

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -10,7 +10,7 @@ const sourcemap = require('source-map')
 const assert = require('assert')
 
 require('tap').mochaGlobals()
-require('should')
+const should = require('should')
 
 describe('V8ToIstanbul', async () => {
   describe('constructor', () => {
@@ -194,6 +194,20 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
 
       v8ToIstanbul.destroy()
     })
+  })
+
+  it('destroy cleans up source map', async () => {
+    const v8ToIstanbul = new V8ToIstanbul(
+      pathToFileURL(require.resolve('./fixtures/scripts/empty.compiled.js')).href
+    )
+    await v8ToIstanbul.load()
+    // assertion only to check test data and setup - source map must be loaded,
+    // otherwise destroy would have no effect anyway
+    assert(v8ToIstanbul.sourceMap !== undefined, 'Test fixture must load a source map')
+
+    v8ToIstanbul.destroy()
+
+    should.not.exist(v8ToIstanbul.sourceMap)
   })
 
   // execute JavaScript files in fixtures directory; these


### PR DESCRIPTION
Adds a `destroy` function as counterpart to the existing `load` to cleanup allocated resources after usage, especially memory allocated by the `SourceMapConsumer` from the *source-map* dependency.

Currently the converter creates a new `SourceMapConsumer` during the load operation, however this gets never destroyed properly. Documentation states that "When the SourceMapConsumer will no longer be used anymore, you must call its destroy method." (https://github.com/mozilla/source-map/blob/58819f09018d56ef84dc41ba9c93f554e0645169/README.md#new-sourcemapconsumerrawsourcemap). Failing to cleanup the consumer can trigger errors such as mozilla/source-map/issues/412.