### PR TITLE
Fixed startCol/endCol vs startOffset/endOffset mismatch due to greediness and whitespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.{.js,.json}]
+end_of_line = lf
+indent_size = 2
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 test/fixtures/scripts/needs-compile.js eol=crlf
 test/fixtures/scripts/needs-compile.compiled.js eol=crlf
 test/fixtures/scripts/needs-compile.compiled.js.map eol=crlf
+test/fixtures/scripts/branches.covered.js eol=lf
+test/fixtures/scripts/branches.js eol=lf
+test/fixtures/scripts/functions.js eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage
 node_modules
 .idea
 .vscode
+*.iml
+yarn.lock

--- a/lib/line.js
+++ b/lib/line.js
@@ -4,12 +4,14 @@ module.exports = class CovLine {
     // note that startCol and endCol are absolute positions
     // within a file, not relative to the line.
     this.startCol = startCol
+    this.minCol = startCol + lineStr.length - lineStr.trimStart().length
 
     // the line length itself does not include the newline characters,
     // these are however taken into account when enumerating absolute offset.
     const matchedNewLineChar = lineStr.match(/\r?\n$/u)
     const newLineLength = matchedNewLineChar ? matchedNewLineChar[0].length : 0
     this.endCol = startCol + lineStr.length - newLineLength
+    this.maxCol = startCol + lineStr.trimEnd().length
 
     // we start with all lines having been executed, and work
     // backwards zeroing out lines based on V8 output.

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,0 +1,40 @@
+/**
+ * ...something resembling a binary search, to find the lowest line within the range.
+ * And then you could break as soon as the line is longer than the range...
+ */
+module.exports.sliceRange = (lines, startCol, endCol) => {
+  let lower = 0
+  let upper = lines.length - 1
+
+  let s
+  while (lower <= upper) {
+    s = (lower + upper) >> 1
+    if (startCol < lines[s].startCol) {
+      upper = s - 1
+    } else if (startCol >= lines[s].endCol) {
+      lower = s + 1
+    } else {
+      let e = s + 1
+      while (e < lines.length && endCol > lines[e].startCol) {
+        ++e
+      }
+      return lines.slice(s, e)
+    }
+  }
+  if (s >= 0 && lines[s].startCol >= startCol) {
+    let e = s + 1
+    while (e < lines.length && endCol > lines[e].startCol) {
+      ++e
+    }
+    return lines.slice(s, e)
+  }
+  return []
+}
+
+module.exports.trimRange = (rawSource, range) => {
+  const slice = rawSource.slice(range.startOffset, range.endOffset)
+  return {
+    startOffset: range.startOffset + (slice.length - slice.trimStart().length),
+    endOffset: range.endOffset - (slice.length - slice.trimEnd().length)
+  }
+}

--- a/lib/range.js
+++ b/lib/range.js
@@ -30,3 +30,11 @@ module.exports.sliceRange = (lines, startCol, endCol) => {
   }
   return []
 }
+
+module.exports.trimRange = (rawSource, range) => {
+  const slice = rawSource.slice(range.startOffset, range.endOffset)
+  return {
+    startOffset: range.startOffset + (slice.length - slice.trimStart().length),
+    endOffset: range.endOffset - (slice.length - slice.trimEnd().length)
+  }
+}

--- a/lib/source.js
+++ b/lib/source.js
@@ -1,4 +1,5 @@
 const CovLine = require('./line')
+const { sliceRange } = require('./range')
 const { GREATEST_LOWER_BOUND, LEAST_UPPER_BOUND } = require('source-map').SourceMapConsumer
 
 module.exports = class CovSource {
@@ -75,9 +76,7 @@ module.exports = class CovSource {
   // given a start column and end column in absolute offsets within
   // a source file (0 - EOF), returns the relative line column positions.
   offsetToOriginalRelative (sourceMap, startCol, endCol) {
-    const lines = this.lines.filter((line, i) => {
-      return startCol <= line.endCol && endCol >= line.startCol
-    })
+    const lines = sliceRange(this.lines, startCol, endCol)
     if (!lines.length) return {}
 
     const start = originalPositionTryBoth(
@@ -85,17 +84,16 @@ module.exports = class CovSource {
       lines[0].line,
       Math.max(0, startCol - lines[0].startCol)
     )
+    if (!(start && start.source)) {
+      return {}
+    }
+
     let end = originalEndPositionFor(
       sourceMap,
       lines[lines.length - 1].line,
       endCol - lines[lines.length - 1].startCol
     )
-
-    if (!(start && end)) {
-      return {}
-    }
-
-    if (!(start.source && end.source)) {
+    if (!(end && end.source)) {
       return {}
     }
 

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -43,6 +43,7 @@ module.exports = class V8ToIstanbul {
 
   async load () {
     const rawSource = this.sources.source || await readFile(this.path, 'utf8')
+    this.rawSource = rawSource
     this.rawSourceMap = this.sources.sourceMap ||
       // if we find a source-map (either inline, or a .map file) we load
       // both the transpiled and original source, both of which are used during
@@ -168,6 +169,11 @@ module.exports = class V8ToIstanbul {
           ))
         }
 
+        const {
+          startCol: minCol,
+          endCol: maxCol
+        } = this._maybeRemapStartColEndCol(trimRange(this.rawSource, range))
+
         // record the lines (we record these as statements, such that we're
         // compatible with Istanbul 2.0).
         lines.forEach(line => {
@@ -180,7 +186,7 @@ module.exports = class V8ToIstanbul {
           // set to 0, and is set if the special comment /* c8 ignore next */
           // is used.
 
-          if (startCol <= line.startCol && endCol >= line.endCol && !line.ignore) {
+          if (minCol <= line.minCol && maxCol >= line.maxCol && !line.ignore) {
             line.count = range.count
           }
         })

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -5,6 +5,7 @@ const { fileURLToPath } = require('url')
 const CovBranch = require('./branch')
 const CovFunction = require('./function')
 const CovSource = require('./source')
+const { sliceRange, trimRange } = require('./range')
 const compatError = Error(`requires Node.js ${require('../package.json').engines.node}`)
 let readFile = () => { throw compatError }
 try {
@@ -112,22 +113,25 @@ module.exports = class V8ToIstanbul {
         if (this.excludePath(path)) {
           return
         }
-        const lines = covSource.lines.filter(line => {
-          // Upstream tooling can provide a block with the functionName
-          // (empty-report), this will result in a report that has all
-          // lines zeroed out.
-          if (block.functionName === '(empty-report)') {
-            line.count = 0
-            this.all = true
-            return true
-          }
 
-          return startCol < line.endCol && endCol >= line.startCol
-        })
+        // (empty-report), this will result in a report that has all
+        // lines zeroed out.
+        if (block.functionName === '(empty-report)') {
+          this.all = true
+          covSource.lines.forEach(line => {
+            line.count = 0
+          })
+        }
+
+        const lines = this.all ? covSource.lines : sliceRange(covSource.lines, startCol, endCol)
+        if (!lines.length) {
+          return
+        }
+
         const startLineInstance = lines[0]
         const endLineInstance = lines[lines.length - 1]
 
-        if (block.isBlockCoverage && lines.length) {
+        if (block.isBlockCoverage) {
           this.branches[path] = this.branches[path] || []
           // record branches.
           this.branches[path].push(new CovBranch(
@@ -138,7 +142,7 @@ module.exports = class V8ToIstanbul {
             range.count
           ))
 
-          // if block-level granularity is enabled, we we still create a single
+          // if block-level granularity is enabled, we still create a single
           // CovFunction tracking object for each set of ranges.
           if (block.functionName && i === 0) {
             this.functions[path] = this.functions[path] || []
@@ -151,7 +155,7 @@ module.exports = class V8ToIstanbul {
               range.count
             ))
           }
-        } else if (block.functionName && lines.length) {
+        } else if (block.functionName) {
           this.functions[path] = this.functions[path] || []
           // record functions.
           this.functions[path].push(new CovFunction(

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -5,7 +5,7 @@ const { fileURLToPath } = require('url')
 const CovBranch = require('./branch')
 const CovFunction = require('./function')
 const CovSource = require('./source')
-const { sliceRange } = require('./range')
+const { sliceRange, trimRange } = require('./range')
 const compatError = Error(`requires Node.js ${require('../package.json').engines.node}`)
 let readFile = () => { throw compatError }
 try {

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -781,6 +781,289 @@ Object {
 }
 `
 
+exports['test/v8-to-istanbul.js TAP > must match early return snapshot 1'] = `
+Object {
+  "all": false,
+  "b": Object {
+    "0": Array [
+      1,
+    ],
+    "1": Array [
+      1,
+    ],
+    "2": Array [
+      0,
+    ],
+    "3": Array [
+      1,
+    ],
+  },
+  "branchMap": Object {
+    "0": Object {
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 13,
+            "line": 9,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "1": Object {
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 1,
+            "line": 7,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "2": Object {
+      "line": 3,
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 6,
+        },
+        "start": Object {
+          "column": -1,
+          "line": 3,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 4,
+            "line": 6,
+          },
+          "start": Object {
+            "column": -1,
+            "line": 3,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "3": Object {
+      "line": 4,
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 3,
+            "line": 6,
+          },
+          "start": Object {
+            "column": 2,
+            "line": 4,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+  },
+  "f": Object {
+    "0": 1,
+    "1": 1,
+  },
+  "fnMap": Object {
+    "0": Object {
+      "decl": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "name": "test",
+    },
+    "1": Object {
+      "decl": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "line": 4,
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "name": "bar",
+    },
+  },
+  "s": Object {
+    "0": 1,
+    "1": 1,
+    "2": 1,
+    "3": 1,
+    "4": 1,
+    "5": 1,
+    "6": 1,
+    "7": 1,
+    "8": 1,
+  },
+  "statementMap": Object {
+    "0": Object {
+      "end": Object {
+        "column": 28,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "1": Object {
+      "end": Object {
+        "column": 15,
+        "line": 2,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 2,
+      },
+    },
+    "2": Object {
+      "end": Object {
+        "column": 2,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 3,
+      },
+    },
+    "3": Object {
+      "end": Object {
+        "column": 18,
+        "line": 4,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 4,
+      },
+    },
+    "4": Object {
+      "end": Object {
+        "column": 24,
+        "line": 5,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 5,
+      },
+    },
+    "5": Object {
+      "end": Object {
+        "column": 3,
+        "line": 6,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 6,
+      },
+    },
+    "6": Object {
+      "end": Object {
+        "column": 1,
+        "line": 7,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 7,
+      },
+    },
+    "7": Object {
+      "end": Object {
+        "column": 0,
+        "line": 8,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 8,
+      },
+    },
+    "8": Object {
+      "end": Object {
+        "column": 13,
+        "line": 9,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 9,
+      },
+    },
+  },
+}
+`
+
 exports['test/v8-to-istanbul.js TAP > must match functions snapshot 1'] = `
 Object {
   "all": false,
@@ -2842,7 +3125,7 @@ Object {
     "37": 0,
     "38": 1,
     "39": 1,
-    "4": 1,
+    "4": 2,
     "40": 1,
     "41": 1,
     "42": 1,

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -1877,38 +1877,9 @@ Object {
     "0": Array [
       1,
     ],
-    "1": Array [
-      1,
-    ],
   },
   "branchMap": Object {
     "0": Object {
-      "line": 2,
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 8,
-        },
-        "start": Object {
-          "column": -1,
-          "line": 2,
-        },
-      },
-      "locations": Array [
-        Object {
-          "end": Object {
-            "column": 7,
-            "line": 8,
-          },
-          "start": Object {
-            "column": -1,
-            "line": 2,
-          },
-        },
-      ],
-      "type": "branch",
-    },
-    "1": Object {
       "line": 2,
       "loc": Object {
         "end": Object {

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -279,8 +279,8 @@ Object {
       "line": 35,
       "loc": Object {
         "end": Object {
-          "column": 0,
-          "line": 37,
+          "column": 29,
+          "line": 36,
         },
         "start": Object {
           "column": -1,
@@ -290,8 +290,8 @@ Object {
       "locations": Array [
         Object {
           "end": Object {
-            "column": 0,
-            "line": 37,
+            "column": 29,
+            "line": 36,
           },
           "start": Object {
             "column": -1,

--- a/test/fixtures/early-return.js
+++ b/test/fixtures/early-return.js
@@ -1,0 +1,47 @@
+module.exports = {
+  describe: "early return",
+  coverageV8: {
+    "scriptId": "61",
+    "url": "./test/fixtures/scripts/early.return.js",
+    "functions": [
+      {
+        "functionName": "",
+        "ranges": [
+          {
+            "startOffset": 0,
+            "endOffset": 112,
+            "count": 1
+          }
+        ],
+        "isBlockCoverage": true
+      },
+      {
+        "functionName": "test",
+        "ranges": [
+          {
+            "startOffset": 0,
+            "endOffset": 97,
+            "count": 1
+          },
+          {
+            "startOffset": 44,
+            "endOffset": 96,
+            "count": 0
+          }
+        ],
+        "isBlockCoverage": true
+      },
+      {
+        "functionName": "bar",
+        "ranges": [
+          {
+            "startOffset": 50,
+            "endOffset": 95,
+            "count": 1
+          }
+        ],
+        "isBlockCoverage": true
+      }
+    ]
+  }
+};

--- a/test/fixtures/scripts/early.return.js
+++ b/test/fixtures/scripts/early.return.js
@@ -1,0 +1,9 @@
+function test(foo = "foo") {
+  return {bar};
+  
+  function bar() {
+    console.log("test");
+  }
+}
+
+test().bar();


### PR DESCRIPTION
This PR aims at solve #170 and solve #159.

I implemented the kind of binary search that @bcoe suggested in #159 and I tweaked the range check because the
I noticed that the = in
https://github.com/istanbuljs/v8-to-istanbul/blob/53c1cd89cb46f4cd2c0a23cdb31715de09716a2a/lib/source.js#L78-L80
seems to be what was causing #170 because tends to overflow on unmapped lines, the range is considered invalid and as a result there are false positives in coverage.

I am keen to investigate and fix also #81 as part of this