### PR TITLE
whitespace trimming approach to fix #81

### DIFF
--- a/lib/line.js
+++ b/lib/line.js
@@ -4,12 +4,14 @@ module.exports = class CovLine {
     // note that startCol and endCol are absolute positions
     // within a file, not relative to the line.
     this.startCol = startCol
+    this.minCol = startCol + lineStr.length - lineStr.trimStart().length
 
     // the line length itself does not include the newline characters,
     // these are however taken into account when enumerating absolute offset.
     const matchedNewLineChar = lineStr.match(/\r?\n$/u)
     const newLineLength = matchedNewLineChar ? matchedNewLineChar[0].length : 0
     this.endCol = startCol + lineStr.length - newLineLength
+    this.maxCol = startCol + lineStr.trimEnd().length
 
     // we start with all lines having been executed, and work
     // backwards zeroing out lines based on V8 output.

--- a/lib/range.js
+++ b/lib/range.js
@@ -33,3 +33,11 @@ module.exports.sliceRange = (lines, startCol, endCol, inclusive = false) => {
 
   return lines.slice(start, end)
 }
+
+module.exports.trimRange = (rawSource, range) => {
+  const slice = rawSource.slice(range.startOffset, range.endOffset)
+  return {
+    startOffset: range.startOffset + (slice.length - slice.trimStart().length),
+    endOffset: range.endOffset - (slice.length - slice.trimEnd().length)
+  }
+}

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -183,11 +183,11 @@ module.exports = class V8ToIstanbul {
           ))
         }
 
-        let range1 = trimRange(this.rawSource, range);
+        const trimmedRange = trimRange(this.rawSource, range)
         const {
           startCol: minCol,
           endCol: maxCol
-        } = this._maybeRemapStartColEndCol(range1)
+        } = this._maybeRemapStartColEndCol(trimmedRange)
 
         // record the lines (we record these as statements, such that we're
         // compatible with Istanbul 2.0).

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -7,7 +7,7 @@ const { fileURLToPath } = require('url')
 const CovBranch = require('./branch')
 const CovFunction = require('./function')
 const CovSource = require('./source')
-const { sliceRange } = require('./range')
+const { sliceRange, trimRange } = require('./range')
 const compatError = Error(`requires Node.js ${require('../package.json').engines.node}`)
 let readFile = () => { throw compatError }
 try {
@@ -45,6 +45,7 @@ module.exports = class V8ToIstanbul {
 
   async load () {
     const rawSource = this.sources.source || await readFile(this.path, 'utf8')
+    this.rawSource = rawSource
     this.rawSourceMap = this.sources.sourceMap ||
       // if we find a source-map (either inline, or a .map file) we load
       // both the transpiled and original source, both of which are used during
@@ -182,6 +183,12 @@ module.exports = class V8ToIstanbul {
           ))
         }
 
+        let range1 = trimRange(this.rawSource, range);
+        const {
+          startCol: minCol,
+          endCol: maxCol
+        } = this._maybeRemapStartColEndCol(range1)
+
         // record the lines (we record these as statements, such that we're
         // compatible with Istanbul 2.0).
         lines.forEach(line => {
@@ -194,7 +201,7 @@ module.exports = class V8ToIstanbul {
           // set to 0, and is set if the special comment /* c8 ignore next */
           // is used.
 
-          if (startCol <= line.startCol && endCol >= line.endCol && !line.ignore) {
+          if (minCol <= line.minCol && maxCol >= line.maxCol && !line.ignore) {
             line.count = range.count
           }
         })

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -781,6 +781,260 @@ Object {
 }
 `
 
+exports['test/v8-to-istanbul.js TAP > must match early return snapshot 1'] = `
+Object {
+  "all": false,
+  "b": Object {
+    "0": Array [
+      1,
+    ],
+    "1": Array [
+      1,
+    ],
+    "2": Array [
+      1,
+    ],
+  },
+  "branchMap": Object {
+    "0": Object {
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 13,
+            "line": 9,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "1": Object {
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 1,
+            "line": 7,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "2": Object {
+      "line": 4,
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 3,
+            "line": 6,
+          },
+          "start": Object {
+            "column": 2,
+            "line": 4,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+  },
+  "f": Object {
+    "0": 1,
+    "1": 1,
+  },
+  "fnMap": Object {
+    "0": Object {
+      "decl": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "name": "test",
+    },
+    "1": Object {
+      "decl": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "line": 4,
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "name": "bar",
+    },
+  },
+  "s": Object {
+    "0": 1,
+    "1": 1,
+    "2": 1,
+    "3": 1,
+    "4": 1,
+    "5": 1,
+    "6": 1,
+    "7": 1,
+    "8": 1,
+  },
+  "statementMap": Object {
+    "0": Object {
+      "end": Object {
+        "column": 28,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "1": Object {
+      "end": Object {
+        "column": 15,
+        "line": 2,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 2,
+      },
+    },
+    "2": Object {
+      "end": Object {
+        "column": 2,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 3,
+      },
+    },
+    "3": Object {
+      "end": Object {
+        "column": 18,
+        "line": 4,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 4,
+      },
+    },
+    "4": Object {
+      "end": Object {
+        "column": 24,
+        "line": 5,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 5,
+      },
+    },
+    "5": Object {
+      "end": Object {
+        "column": 3,
+        "line": 6,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 6,
+      },
+    },
+    "6": Object {
+      "end": Object {
+        "column": 1,
+        "line": 7,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 7,
+      },
+    },
+    "7": Object {
+      "end": Object {
+        "column": 0,
+        "line": 8,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 8,
+      },
+    },
+    "8": Object {
+      "end": Object {
+        "column": 13,
+        "line": 9,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 9,
+      },
+    },
+  },
+}
+`
+
 exports['test/v8-to-istanbul.js TAP > must match functions snapshot 1'] = `
 Object {
   "all": false,
@@ -2871,7 +3125,7 @@ Object {
     "37": 0,
     "38": 1,
     "39": 1,
-    "4": 1,
+    "4": 2,
     "40": 1,
     "41": 1,
     "42": 1,

--- a/test/fixtures/early-return.js
+++ b/test/fixtures/early-return.js
@@ -1,0 +1,47 @@
+module.exports = {
+  describe: "early return",
+  coverageV8: {
+    "scriptId": "61",
+    "url": "./test/fixtures/scripts/early.return.js",
+    "functions": [
+      {
+        "functionName": "",
+        "ranges": [
+          {
+            "startOffset": 0,
+            "endOffset": 112,
+            "count": 1
+          }
+        ],
+        "isBlockCoverage": true
+      },
+      {
+        "functionName": "test",
+        "ranges": [
+          {
+            "startOffset": 0,
+            "endOffset": 97,
+            "count": 1
+          },
+          {
+            "startOffset": 44,
+            "endOffset": 96,
+            "count": 0
+          }
+        ],
+        "isBlockCoverage": true
+      },
+      {
+        "functionName": "bar",
+        "ranges": [
+          {
+            "startOffset": 50,
+            "endOffset": 95,
+            "count": 1
+          }
+        ],
+        "isBlockCoverage": true
+      }
+    ]
+  }
+};

--- a/test/fixtures/scripts/early.return.js
+++ b/test/fixtures/scripts/early.return.js
@@ -1,0 +1,9 @@
+function test(foo = "foo") {
+  return {bar};
+  
+  function bar() {
+    console.log("test");
+  }
+}
+
+test().bar();


### PR DESCRIPTION
This PR aims at improving the precision of the v8 range mapping trimming the whitespaces.

e.g. #81 is caused by:
https://github.com/istanbuljs/v8-to-istanbul/blob/53c1cd89cb46f4cd2c0a23cdb31715de09716a2a/lib/v8-to-istanbul.js#L179-L181
because the v8 startOffset is 50 while the line startCol is 48.

I introduced minCol and maxCol which take into account the gaps caused by whitespaces and now the matching
seems more accurate.

With the trimming in place c8 tests are all green except from the following 7 cases:
```
    source-maps
      ✔ does not attempt to load source map URLs that aren't (195ms)
      TypeScript
        ✔ remaps branches (219ms)
        1) remaps classes
      UglifyJS
        ✔ remaps branches (221ms)
        2) remaps classes
      nyc
        ✔ remaps branches (217ms)
        3) remaps classes
      rollup
        ✔ remaps branches (216ms)
        4) remaps classes
      ts-node
        5) reads source-map from cache, and applies to coverage
    --all
      ✔ reports coverage for unloaded js files as 0 for line, branch and function (311ms)
      6) reports coverage for unloaded transpiled ts files as 0 for line, branch and function
      7) reports coverage for unloaded ts files as 0 for line, branch and function when using ts-node
      ✔ should allow for --all to be used in conjunction with --check-coverage (298ms)
      ✔ should allow for --all to be used with the check-coverage command (2 invocations) (544ms)

```
These differences look promising (the new range cover the method signatures which in the past were missing):
```
  1) AssertionError: expected value to match snapshot c8 source-maps TypeScript remaps classes 1
      + expected - actual
       -----------------------|---------|----------|---------|---------|-------------------
       File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       -----------------------|---------|----------|---------|---------|-------------------
      -All files              |   75.75 |    85.71 |      60 |   75.75 |                   
      - classes.typescript.ts |   75.75 |    85.71 |      60 |   75.75 | 12-13,20-22,26-28 
      +All files              |   81.81 |    85.71 |      60 |   81.81 |                   
      + classes.typescript.ts |   81.81 |    85.71 |      60 |   81.81 | 12-13,21-22,27-28 
       -----------------------|---------|----------|---------|---------|-------------------

  2) AssertionError: expected value to match snapshot c8 source-maps UglifyJS remaps classes 1
      + expected - actual
       ------------|---------|----------|---------|---------|-------------------
       File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       ------------|---------|----------|---------|---------|-------------------
      -All files   |   77.77 |       80 |      60 |   77.77 |                   
      - classes.js |   77.77 |       80 |      60 |   77.77 | 6-7,14-15,20-21   
      +All files   |   85.18 |       80 |      60 |   85.18 |                   
      + classes.js |   85.18 |       80 |      60 |   85.18 | 6-7,15,21         
       ------------|---------|----------|---------|---------|-------------------

  3) AssertionError: expected value to match snapshot c8 source-maps nyc remaps classes 1
      + expected - actual
       ------------|---------|----------|---------|---------|-------------------
       File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       ------------|---------|----------|---------|---------|-------------------
      -All files   |   70.37 |    83.33 |      60 |   70.37 |                   
      - classes.js |   70.37 |    83.33 |      60 |   70.37 | 7-8,14-16,20-22   
      +All files   |   77.77 |    83.33 |      60 |   77.77 |                   
      + classes.js |   77.77 |    83.33 |      60 |   77.77 | 7-8,15-16,21-22   
       ------------|---------|----------|---------|---------|-------------------
  4) AssertionError: expected value to match snapshot c8 source-maps rollup remaps classes 1
      + expected - actual
       ------------|---------|----------|---------|---------|-------------------
       File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       ------------|---------|----------|---------|---------|-------------------
      -All files   |   71.42 |    83.33 |      60 |   71.42 |                   
      +All files   |   78.57 |    83.33 |      60 |   78.57 |                   
        class-1.js |     100 |      100 |     100 |     100 |                   
      - class-2.js |   65.21 |    83.33 |      60 |   65.21 | 7-8,14-16,20-22   
      + class-2.js |   73.91 |    83.33 |      60 |   73.91 | 7-8,15-16,21-22   
       ------------|---------|----------|---------|---------|-------------------
  5) AssertionError: expected value to match snapshot c8 source-maps ts-node reads source-map from cache, and applies to coverage 1
      + expected - actual
       ------------------|---------|----------|---------|---------|-------------------
       File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       ------------------|---------|----------|---------|---------|-------------------
      -All files         |   85.29 |    83.33 |      80 |   85.29 |                   
      - ts-node-basic.ts |   85.29 |    83.33 |      80 |   85.29 | 12-13,27-29       
      +All files         |   88.23 |    83.33 |      80 |   88.23 |                   
      + ts-node-basic.ts |   88.23 |    83.33 |      80 |   88.23 | 12-13,28-29       
       ------------------|---------|----------|---------|---------|-------------------
```
Instead I am still investigating these two cases (the min/max ranges seem to be remapped correctly by source maps while somethins is off with `this.rawSource` which breaks `trimRange`):
```
  6) AssertionError: expected value to match snapshot c8 --all reports coverage for unloaded transpiled ts files as 0 for line, branch and function 1
      + expected - actual
       -----------------|---------|----------|---------|---------|-------------------
       File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       -----------------|---------|----------|---------|---------|-------------------
      -All files        |   67.85 |    57.14 |      50 |   67.85 |                   
      - ts-compiled     |    82.6 |    66.66 |     100 |    82.6 |                   
      -  loaded.ts      |   78.94 |    66.66 |     100 |   78.94 | 4-5,17-18         
      +All files        |   64.28 |    57.14 |      50 |   64.28 |                   
      + ts-compiled     |   78.26 |    66.66 |     100 |   78.26 |                   
      +  loaded.ts      |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18         
         main.ts        |     100 |      100 |     100 |     100 |                   
        ts-compiled/dir |       0 |        0 |       0 |       0 |                   
         unloaded.ts    |       0 |        0 |       0 |       0 | 1-5               
       -----------------|---------|----------|---------|---------|-------------------

  7) AssertionError: expected value to match snapshot c8 --all reports coverage for unloaded ts files as 0 for line, branch and function when using ts-node 1
      + expected - actual
       --------------|---------|----------|---------|---------|-------------------
       File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
       --------------|---------|----------|---------|---------|-------------------
      -All files     |   67.85 |    57.14 |      50 |   67.85 |                   
      - ts-only      |    82.6 |    66.66 |     100 |    82.6 |                   
      -  loaded.ts   |   78.94 |    66.66 |     100 |   78.94 | 4-5,17-18         
      +All files     |   64.28 |    57.14 |      50 |   64.28 |                   
      + ts-only      |   78.26 |    66.66 |     100 |   78.26 |                   
      +  loaded.ts   |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18         
         main.ts     |     100 |      100 |     100 |     100 |                   
        ts-only/dir  |       0 |        0 |       0 |       0 |                   
         unloaded.ts |       0 |        0 |       0 |       0 | 1-5               
       --------------|---------|----------|---------|---------|-------------------
```
I preferred to open the PR early to start receiving feedback. I will try to keep the noise to the minimum though!

I am keen to optimise the code but that once we are sure that the changes in the coverage are all good.
