### PR TITLE
Fine tune slice range to fix #170

### DIFF
--- a/lib/range.js
+++ b/lib/range.js
@@ -23,7 +23,7 @@ module.exports.sliceRange = (lines, startCol, endCol, inclusive = false) => {
     }
   }
   if (start === end) {
-    while (end < lines.length && extStartCol < lines[end].endCol && endCol >= lines[end].startCol) {
+    while (end < lines.length && extStartCol < lines[end].endCol && endCol > lines[end].startCol) {
       ++end
     }
     return lines.slice(start, end)

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -279,8 +279,8 @@ Object {
       "line": 35,
       "loc": Object {
         "end": Object {
-          "column": 0,
-          "line": 37,
+          "column": 29,
+          "line": 36,
         },
         "start": Object {
           "column": -1,
@@ -290,8 +290,8 @@ Object {
       "locations": Array [
         Object {
           "end": Object {
-            "column": 0,
-            "line": 37,
+            "column": 29,
+            "line": 36,
           },
           "start": Object {
             "column": -1,

--- a/test/range.js
+++ b/test/range.js
@@ -29,7 +29,18 @@ describe('range', () => {
         { startCol: 25, endCol: 30 }
       ]
       sliceRange(SIX_LINES, 5, 14).should.eql(SIX_LINES.slice(1, 3))
-      sliceRange(SIX_LINES, 15, 21).should.eql(SIX_LINES.slice(3, 5))
+      sliceRange(SIX_LINES, 15, 22).should.eql(SIX_LINES.slice(3, 5))
+    })
+    it('exclusive/inclusive ranges', () => {
+      const SIX_LINES = [
+        { startCol: 0, endCol: 14 },
+        { startCol: 15, endCol: 20 },
+        { startCol: 21, endCol: 24 },
+        { startCol: 25, endCol: 30 }
+      ]
+      sliceRange(SIX_LINES, 20, 24).should.eql([])
+      sliceRange(SIX_LINES, 20, 24, true).should.eql(SIX_LINES.slice(1, 3))
+      sliceRange(SIX_LINES, 21, 25).should.eql(SIX_LINES.slice(2, 3))
     })
   })
 })


### PR DESCRIPTION
@bcoe I isolated in this PR the fix for #170

In the PR #172 I implemented 
https://github.com/istanbuljs/v8-to-istanbul/blob/1f357fa2e994385b56ba505ca199eda46b233a89/lib/range.js#L26-L28
with a conservative mindset leaving the `endCol >= lines.startCol` that was originally in
https://github.com/istanbuljs/v8-to-istanbul/blob/53c1cd89cb46f4cd2c0a23cdb31715de09716a2a/lib/source.js#L78-L81
and this `>=` is the cause of #170 

This PR aims at fixing #170 with the least side effects as possible.

### C8 is fine
<img width="707" alt="Screenshot 2022-01-19 at 02 12 14" src="https://user-images.githubusercontent.com/160981/150051712-3391e62c-23f3-4f09-92ff-7923b72ef27e.png">

### The changes in the snapshot reflect the end of the range being exclusive (https://v8.dev/blog/javascript-code-coverage)
<img width="977" alt="Screenshot 2022-01-19 at 02 31 33" src="https://user-images.githubusercontent.com/160981/150053009-6c76dfaa-2bff-49eb-9775-dda13096e0ee.png">
while 538 corresponds to 37:0 so line 37 cannot be taken in the range
