### PR TITLE
Retry end (fixes #170)

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -93,6 +93,17 @@ module.exports = class CovSource {
       lines[lines.length - 1].line,
       endCol - lines[lines.length - 1].startCol
     )
+    if (!end) {
+      let lineNum = lines.length - 2
+      while (!end && lineNum > 0) {
+        end = originalEndPositionFor(
+          sourceMap,
+          lines[lineNum].line,
+          endCol - lines[lineNum].startCol
+        )
+        --lineNum
+      }
+    }
     if (!(end && end.source)) {
       return {}
     }

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -2008,7 +2008,7 @@ Object {
   "all": false,
   "b": Object {
     "0": Array [
-      0,
+      1,
     ],
     "1": Array [
       0,
@@ -2020,23 +2020,52 @@ Object {
       0,
     ],
     "4": Array [
-      1,
+      0,
     ],
     "5": Array [
-      0,
+      1,
     ],
     "6": Array [
       0,
     ],
     "7": Array [
-      1,
+      0,
     ],
     "8": Array [
+      1,
+    ],
+    "9": Array [
       0,
     ],
   },
   "branchMap": Object {
     "0": Object {
+      "line": 1,
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 6,
+            "line": 30,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "1": Object {
       "line": 5,
       "loc": Object {
         "end": Object {
@@ -2062,7 +2091,7 @@ Object {
       ],
       "type": "branch",
     },
-    "1": Object {
+    "2": Object {
       "line": 8,
       "loc": Object {
         "end": Object {
@@ -2088,7 +2117,7 @@ Object {
       ],
       "type": "branch",
     },
-    "2": Object {
+    "3": Object {
       "line": 11,
       "loc": Object {
         "end": Object {
@@ -2114,7 +2143,7 @@ Object {
       ],
       "type": "branch",
     },
-    "3": Object {
+    "4": Object {
       "line": 14,
       "loc": Object {
         "end": Object {
@@ -2140,7 +2169,7 @@ Object {
       ],
       "type": "branch",
     },
-    "4": Object {
+    "5": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
@@ -2166,7 +2195,7 @@ Object {
       ],
       "type": "branch",
     },
-    "5": Object {
+    "6": Object {
       "line": 1,
       "loc": Object {
         "end": Object {
@@ -2192,7 +2221,7 @@ Object {
       ],
       "type": "branch",
     },
-    "6": Object {
+    "7": Object {
       "line": 2,
       "loc": Object {
         "end": Object {
@@ -2218,7 +2247,7 @@ Object {
       ],
       "type": "branch",
     },
-    "7": Object {
+    "8": Object {
       "line": 20,
       "loc": Object {
         "end": Object {
@@ -2244,7 +2273,7 @@ Object {
       ],
       "type": "branch",
     },
-    "8": Object {
+    "9": Object {
       "line": 29,
       "loc": Object {
         "end": Object {


### PR DESCRIPTION
This PR aims at improving the `startCol`/`endCol` (source)mapping by finding the greatest lower bound when there's a start but an exact mapping for the end itself doesn't exist.
This append in particular when build tools (like `esbuild` o `rollup`) do not to map `}` so instead of it we pick the latest mapped statement.

There's one change in v8 tests snapshot and looking carefully at it this is the addition of a branch which was missed before (see selection):
![image](https://user-images.githubusercontent.com/160981/155913201-016cda23-0da5-491d-8976-54e7b0f2a6b3.png)

A bit more interesting is what happens in `c8` where only 1 test fails:
```
  51 passing (21s)
  1 failing

      AssertionError: expected value to match snapshot c8 source-maps TypeScript remaps branches 1
      + expected - actual

       a = false
       ------------------------|---------|----------|---------|---------|-------------------
       File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
       ------------------------|---------|----------|---------|---------|-------------------
      -All files               |      84 |    57.14 |     100 |      84 |
      - branches.typescript.ts |      84 |    57.14 |     100 |      84 | 7,11-12,18
      +All files               |      84 |       50 |     100 |      84 |
      + branches.typescript.ts |      84 |       50 |     100 |      84 | 7,11-12,18
       ------------------------|---------|----------|---------|---------|-------------------
```
Although looking at the source code it seems that there are 3+3=6 branches and 3 of them are never touched
hence 50% coverage when looking at what v8 blocks contain:
![image](https://user-images.githubusercontent.com/160981/155913616-5d1d992b-7bc2-4cf2-b156-bdd9efe06cb9.png)
we can see that out of 7 ranges 3 are not covered.
And according to:
https://github.com/istanbuljs/v8-to-istanbul/blob/1f357fa2e994385b56ba505ca199eda46b233a89/lib/v8-to-istanbul.js#L154-L160
it seems that each range is a branch so the 4/7=57.14% should be correct.

@bcoe what do you think?
