### PR TITLE
node 10 shebang issue

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -237,7 +237,7 @@ function getShebangLength (source) {
   if (isPreNode12 && source.indexOf('#!') === 0) {
     const match = source.match(/(?<shebang>#!.*)/)
     if (match) {
-      return match.groups.shebang.length
+      return match.groups.shebang.length + 1
     }
   } else {
     return 0

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -1877,6 +1877,9 @@ Object {
     "0": Array [
       1,
     ],
+    "1": Array [
+      1,
+    ],
   },
   "branchMap": Object {
     "0": Object {
@@ -1899,6 +1902,32 @@ Object {
           },
           "start": Object {
             "column": 0,
+            "line": 2,
+          },
+        },
+      ],
+      "type": "branch",
+    },
+    "1": Object {
+      "line": 2,
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 7,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 1,
             "line": 2,
           },
         },


### PR DESCRIPTION
@bcoe this PR aims at fixing https://github.com/bcoe/c8/issues/385

I am investigating what's the best solution because although this change fixes the shebang test few other c8 test fail with node 10.

  c8
    check-coverage
      1) exits with 1 if coverage is below threshold
      2) allows threshold to be applied on per-file basis
      3) allows --check-coverage when executing script
      4) check-coverage command with --100
    report
      5) generates report from existing temporary files
      6) supports --check-coverage, when generating reports

  46 passing (22s)
  6 failing

I am trying to understand what causes these discrepancies and I am also challenging the way the sliceRange works.

