### PR TITLE
chore: test on node 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [10, 12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
I haven't verified locally, but with #186 this module should work fine on v18 as well