### PR TITLE
fix: handle end out of range errors

### DIFF
--- a/lib/range.js
+++ b/lib/range.js
@@ -16,7 +16,7 @@ module.exports.sliceRange = (lines, startCol, endCol, inclusive = false) => {
     if (startCol >= lines[mid].endCol) {
       start = mid + 1
     } else if (endCol < lines[mid].startCol) {
-      end = Math.max(mid - 1, start);
+      end = Math.max(mid - 1, start)
     } else {
       end = mid
       while (mid >= 0 && startCol < lines[mid].endCol && endCol >= lines[mid].startCol) {

--- a/lib/range.js
+++ b/lib/range.js
@@ -16,7 +16,7 @@ module.exports.sliceRange = (lines, startCol, endCol, inclusive = false) => {
     if (startCol >= lines[mid].endCol) {
       start = mid + 1
     } else if (endCol < lines[mid].startCol) {
-      end = mid - 1
+      end = Math.max(mid - 1, start);
     } else {
       end = mid
       while (mid >= 0 && startCol < lines[mid].endCol && endCol >= lines[mid].startCol) {

--- a/test/range.js
+++ b/test/range.js
@@ -9,6 +9,13 @@ describe('range', () => {
     it('can deal with empty arrays', () => {
       sliceRange([], 0, 1).should.eql([])
     })
+    it('can deal with out of range indexes', () => {
+      const LINES = [
+        { startCol: 0, endCol: 3 }
+      ]
+      sliceRange(LINES, 0, -1).should.eql([])
+      sliceRange(LINES, 5, 3).should.eql([])
+    })
     it('can find lines that match exactly', () => {
       const THREE_LINES = [
         { startCol: 0, endCol: 10 },


### PR DESCRIPTION
Fixes issue `Cannot read properties of undefined (reading 'endCol')` in `lib/range.js`

See comment by @devcorraliza on  https://github.com/istanbuljs/v8-to-istanbul/issues/198#issuecomment-1310007608 for context