### PR TITLE
feat: ignore hint to support other content as well

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -51,22 +51,22 @@ module.exports = class CovSource {
    * @return {{count?: number, start?: boolean, stop?: boolean}|undefined}
    */
   _parseIgnore (lineStr) {
-    const testIgnoreNextLines = lineStr.match(/^\W*\/\* c8 ignore next (?<count>[0-9]+) *\*\/\W*$/)
+    const testIgnoreNextLines = lineStr.match(/^\W*\/\* c8 ignore next (?<count>[0-9]+)/)
     if (testIgnoreNextLines) {
       return { count: Number(testIgnoreNextLines.groups.count) }
     }
 
     // Check if comment is on its own line.
-    if (lineStr.match(/^\W*\/\* c8 ignore next *\*\/\W*$/)) {
+    if (lineStr.match(/^\W*\/\* c8 ignore next/)) {
       return { count: 1 }
     }
 
-    if (lineStr.match(/\/\* c8 ignore next \*\//)) {
+    if (lineStr.match(/\/\* c8 ignore next/)) {
       // Won't ignore successive lines, but the current line will be ignored.
       return { count: 0 }
     }
 
-    const testIgnoreStartStop = lineStr.match(/\/\* c8 ignore (?<mode>start|stop) *\*\//)
+    const testIgnoreStartStop = lineStr.match(/\/\* c8 ignore (?<mode>start|stop)/)
     if (testIgnoreStartStop) {
       if (testIgnoreStartStop.groups.mode === 'start') return { start: true }
       if (testIgnoreStartStop.groups.mode === 'stop') return { stop: true }

--- a/test/source.js
+++ b/test/source.js
@@ -128,5 +128,43 @@ describe('Source', () => {
       source.lines[8].ignore.should.equal(false)
       source.lines[9].ignore.should.equal(false)
     })
+
+    it('ignore hint accepts other text content', () => {
+      const sourceRaw = `
+      const a = 33
+
+      /* c8 ignore next -- reasoning why this is ignored */
+      const b = 99
+
+      /* c8 ignore start: reasoning here */
+      function ignoreMe() {
+        // ...
+      }
+      /* c8 ignore stop -- @preserve */
+
+      const c = a ? true /* c8 ignore next reasoning here */ : false
+
+      /* c8 ignore next 2 -- ignores next two lines */
+      const a = 33
+      const a = 99
+      `
+      const source = new CovSource(sourceRaw, 0)
+      source.lines[1].ignore.should.equal(false)
+      source.lines[2].ignore.should.equal(false)
+      source.lines[3].ignore.should.equal(true)
+      source.lines[4].ignore.should.equal(true)
+      source.lines[5].ignore.should.equal(false)
+      source.lines[6].ignore.should.equal(true)
+      source.lines[7].ignore.should.equal(true)
+      source.lines[8].ignore.should.equal(true)
+      source.lines[9].ignore.should.equal(true)
+      source.lines[10].ignore.should.equal(true)
+      source.lines[11].ignore.should.equal(false)
+      source.lines[12].ignore.should.equal(true)
+      source.lines[13].ignore.should.equal(false)
+      source.lines[14].ignore.should.equal(true)
+      source.lines[15].ignore.should.equal(true)
+      source.lines[16].ignore.should.equal(true)
+    })
   })
 })


### PR DESCRIPTION
Adds support for ignore hints to contain more text content, e.g. reasoning for ignoring code.

Changes the patterns to check the start of the ignore hint only. No need to verify that the pattern actually stops. If this method does not work, let me know and I'll reimplement the patterns. 

Closes https://github.com/bcoe/c8/issues/181.


