### PR TITLE
test: empty coverage

### DIFF
--- a/test/fixtures/scripts/uncovered.js
+++ b/test/fixtures/scripts/uncovered.js
@@ -1,0 +1,7 @@
+function uncoveredFunction() {
+  return "Hello world";
+}
+
+if ("Branches here" === false) {
+  uncoveredFunction();
+}

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -207,6 +207,32 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
     assert(v8ToIstanbul.sourceMap !== undefined)
   })
 
+  it('empty coverage marks all lines uncovered', async () => {
+    const filename = require.resolve('./fixtures/scripts/uncovered.js')
+    const v8ToIstanbul = new V8ToIstanbul(filename)
+
+    await v8ToIstanbul.load()
+    v8ToIstanbul.applyCoverage([{
+      functionName: '(empty-report)',
+      ranges: [{
+        startOffset: 0,
+        endOffset: lstatSync(filename).size,
+        count: 0
+      }],
+      isBlockCoverage: true
+    }])
+
+    v8ToIstanbul.toIstanbul()[filename].s.should.eql({
+      0: 0,
+      1: 0,
+      2: 0,
+      3: 0,
+      4: 0,
+      5: 0,
+      6: 0
+    })
+  })
+
   // execute JavaScript files in fixtures directory; these
   // files contain the raw v8 output along with a set of
   // assertions. the original scripts can be found in the


### PR DESCRIPTION
- Adds test case for #74

While looking into possible bug related to `wrapperLength` usage with "empty coverage" case I noticed there is no test case for #74. 