### PR TITLE
fix: ignore hint to mark uncovered files statements and lines

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -274,7 +274,7 @@ module.exports = class V8ToIstanbul {
     }
     source.lines.forEach((line, index) => {
       statements.statementMap[`${index}`] = line.toIstanbul()
-      statements.s[`${index}`] = line.count
+      statements.s[`${index}`] = line.ignore ? 1 : line.count
     })
     return statements
   }

--- a/test/fixtures/scripts/ignored.lines.js
+++ b/test/fixtures/scripts/ignored.lines.js
@@ -1,0 +1,4 @@
+/* c8 ignore next 3 */
+function sum(a, b) {
+  return a + b;
+};

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -139,6 +139,32 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       }])
       Object.keys(v8ToIstanbul.toIstanbul()).should.eql(['/src/index.ts', '/src/utils.ts'].map(path.normalize))
     })
+
+    it('ignore hint marks statements of uncovered file as covered', async () => {
+      const filename = require.resolve('./fixtures/scripts/ignored.lines.js')
+      const source = readFileSync(filename, 'utf-8')
+      const v8ToIstanbul = new V8ToIstanbul(pathToFileURL(filename).href)
+      await v8ToIstanbul.load()
+
+      v8ToIstanbul.applyCoverage([
+        {
+          functionName: '(empty-report)',
+          ranges: [
+            {
+              startOffset: 0,
+              endOffset: source.length,
+              count: 0
+            }
+          ],
+          isBlockCoverage: true
+        }
+      ])
+
+      const coverageMap = v8ToIstanbul.toIstanbul()
+      const { s } = coverageMap[filename]
+
+      assert.deepStrictEqual(s, { 0: 1, 1: 1, 2: 1, 3: 1 })
+    })
   })
 
   describe('source map format edge cases', () => {


### PR DESCRIPTION
- Fixes #217 
