### PR TITLE
feat: support `/* v8 ignore` ignore hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ Sometimes you might find yourself wanting to ignore uncovered lines
 in your application (for example, perhaps you run your tests in Linux, but
 there's code that only executes on Windows).
 
-To ignore lines, use the special comment `/* c8 ignore next */`.
+To ignore lines, use the special comment `/* v8 ignore next */`.
+
+**NOTE**: Before version `9.2.0` the ignore hint had to contain `c8` keyword, e.g. `/* c8 ignore ...`.
 
 ### ignoring the next line
 
 ```js
 const myVariable = 99
-/* c8 ignore next */
+/* v8 ignore next */
 if (process.platform === 'win32') console.info('hello world')
 ```
 
@@ -54,7 +56,7 @@ if (process.platform === 'win32') console.info('hello world')
 
 ```js
 const myVariable = 99
-/* c8 ignore next 3 */
+/* v8 ignore next 3 */
 if (process.platform === 'win32') {
   console.info('hello world')
 }
@@ -63,18 +65,18 @@ if (process.platform === 'win32') {
 ### ignoring all lines until told
 
 ```js
-/* c8 ignore start */
+/* v8 ignore start */
 function dontMindMe() {
   // ...
 }
-/* c8 ignore stop */
+/* v8 ignore stop */
 ```
 
 ### ignoring the same line as the comment
 
 ```js
 const myVariable = 99
-const os = process.platform === 'darwin' ? 'OSXy' /* c8 ignore next */ : 'Windowsy' 
+const os = process.platform === 'darwin' ? 'OSXy' /* v8 ignore next */ : 'Windowsy' 
 ```
 
 ## Testing

--- a/lib/source.js
+++ b/lib/source.js
@@ -47,26 +47,27 @@ module.exports = class CovSource {
    *    c8 ignore next 3
    *    c8 ignore start
    *    c8 ignore stop
+   * And equivalent ones for v8, e.g. v8 ignore next.
    * @param {string} lineStr
    * @return {{count?: number, start?: boolean, stop?: boolean}|undefined}
    */
   _parseIgnore (lineStr) {
-    const testIgnoreNextLines = lineStr.match(/^\W*\/\* c8 ignore next (?<count>[0-9]+)/)
+    const testIgnoreNextLines = lineStr.match(/^\W*\/\* [c|v]8 ignore next (?<count>[0-9]+)/)
     if (testIgnoreNextLines) {
       return { count: Number(testIgnoreNextLines.groups.count) }
     }
 
     // Check if comment is on its own line.
-    if (lineStr.match(/^\W*\/\* c8 ignore next/)) {
+    if (lineStr.match(/^\W*\/\* [c|v]8 ignore next/)) {
       return { count: 1 }
     }
 
-    if (lineStr.match(/\/\* c8 ignore next/)) {
+    if (lineStr.match(/\/\* [c|v]8 ignore next/)) {
       // Won't ignore successive lines, but the current line will be ignored.
       return { count: 0 }
     }
 
-    const testIgnoreStartStop = lineStr.match(/\/\* c8 ignore (?<mode>start|stop)/)
+    const testIgnoreStartStop = lineStr.match(/\/\* [c|v]8 ignore (?<mode>start|stop)/)
     if (testIgnoreStartStop) {
       if (testIgnoreStartStop.groups.mode === 'start') return { start: true }
       if (testIgnoreStartStop.groups.mode === 'stop') return { stop: true }

--- a/test/source.js
+++ b/test/source.js
@@ -70,101 +70,103 @@ describe('Source', () => {
     })
   })
 
-  describe('ignore', () => {
-    it('ignores the next line if /* c8 ignore next */ is on its own line', () => {
-      const sourceRaw = `
-      const a = 33
-      /* c8 ignore next */
-      const a = 99
-      `
-      const source = new CovSource(sourceRaw, 0)
-      source.lines[1].ignore.should.equal(false)
-      source.lines[2].ignore.should.equal(true)
-      source.lines[3].ignore.should.equal(true)
+  for (const prefix of ['c8', 'v8']) {
+    describe(`ignore hint ${prefix}`, () => {
+      it(`ignores the next line if /* ${prefix} ignore next */ is on its own line`, () => {
+        const sourceRaw = `
+        const a = 33
+        /* ${prefix} ignore next */
+        const a = 99
+        `
+        const source = new CovSource(sourceRaw, 0)
+        source.lines[1].ignore.should.equal(false)
+        source.lines[2].ignore.should.equal(true)
+        source.lines[3].ignore.should.equal(true)
+      })
+
+      it(`ignores the next N lines if /* ${prefix} ignore next N */ is used`, () => {
+        const sourceRaw = `
+        /* ${prefix} ignore next 2 */
+        const a = 33
+        const a = 99
+        `
+        const source = new CovSource(sourceRaw, 0)
+        source.lines[1].ignore.should.equal(true)
+        source.lines[2].ignore.should.equal(true)
+        source.lines[3].ignore.should.equal(true)
+      })
+
+      it(`ignores a line that contains /* ${prefix} ignore next */`, () => {
+        const sourceRaw = `
+        const a = foo ? true /* ${prefix} ignore next */ : false
+        const b = 99
+        `
+        const source = new CovSource(sourceRaw, 0)
+        source.lines[1].ignore.should.equal(true)
+        source.lines[2].ignore.should.equal(false)
+      })
+
+      it('ignores lines between start and stop', () => {
+        const sourceRaw = `
+        /* ${prefix} ignore start */
+        function ignoreMe() {
+          // ...
+        }
+        /* ${prefix} ignore stop */
+
+        function doNotIgnoreMe() {
+          // ...
+        }
+        `
+        const source = new CovSource(sourceRaw, 0)
+        source.lines[1].ignore.should.equal(true)
+        source.lines[2].ignore.should.equal(true)
+        source.lines[3].ignore.should.equal(true)
+        source.lines[4].ignore.should.equal(true)
+        source.lines[5].ignore.should.equal(true)
+        source.lines[6].ignore.should.equal(false)
+        source.lines[7].ignore.should.equal(false)
+        source.lines[8].ignore.should.equal(false)
+        source.lines[9].ignore.should.equal(false)
+      })
+
+      it('ignore hint accepts other text content', () => {
+        const sourceRaw = `
+        const a = 33
+
+        /* ${prefix} ignore next -- reasoning why this is ignored */
+        const b = 99
+
+        /* ${prefix} ignore start: reasoning here */
+        function ignoreMe() {
+          // ...
+        }
+        /* ${prefix} ignore stop -- @preserve */
+
+        const c = a ? true /* ${prefix} ignore next reasoning here */ : false
+
+        /* ${prefix} ignore next 2 -- ignores next two lines */
+        const a = 33
+        const a = 99
+        `
+        const source = new CovSource(sourceRaw, 0)
+        source.lines[1].ignore.should.equal(false)
+        source.lines[2].ignore.should.equal(false)
+        source.lines[3].ignore.should.equal(true)
+        source.lines[4].ignore.should.equal(true)
+        source.lines[5].ignore.should.equal(false)
+        source.lines[6].ignore.should.equal(true)
+        source.lines[7].ignore.should.equal(true)
+        source.lines[8].ignore.should.equal(true)
+        source.lines[9].ignore.should.equal(true)
+        source.lines[10].ignore.should.equal(true)
+        source.lines[11].ignore.should.equal(false)
+        source.lines[12].ignore.should.equal(true)
+        source.lines[13].ignore.should.equal(false)
+        source.lines[14].ignore.should.equal(true)
+        source.lines[15].ignore.should.equal(true)
+        source.lines[16].ignore.should.equal(true)
+      })
     })
-
-    it('ignores the next N lines if /* c8 ignore next N */ is used', () => {
-      const sourceRaw = `
-      /* c8 ignore next 2 */
-      const a = 33
-      const a = 99
-      `
-      const source = new CovSource(sourceRaw, 0)
-      source.lines[1].ignore.should.equal(true)
-      source.lines[2].ignore.should.equal(true)
-      source.lines[3].ignore.should.equal(true)
-    })
-
-    it('ignores a line that contains /* c8 ignore next */', () => {
-      const sourceRaw = `
-      const a = foo ? true /* c8 ignore next */ : false
-      const b = 99
-      `
-      const source = new CovSource(sourceRaw, 0)
-      source.lines[1].ignore.should.equal(true)
-      source.lines[2].ignore.should.equal(false)
-    })
-
-    it('ignores lines between start and stop', () => {
-      const sourceRaw = `
-      /* c8 ignore start */
-      function ignoreMe() {
-        // ...
-      }
-      /* c8 ignore stop */
-
-      function doNotIgnoreMe() {
-        // ...
-      }
-      `
-      const source = new CovSource(sourceRaw, 0)
-      source.lines[1].ignore.should.equal(true)
-      source.lines[2].ignore.should.equal(true)
-      source.lines[3].ignore.should.equal(true)
-      source.lines[4].ignore.should.equal(true)
-      source.lines[5].ignore.should.equal(true)
-      source.lines[6].ignore.should.equal(false)
-      source.lines[7].ignore.should.equal(false)
-      source.lines[8].ignore.should.equal(false)
-      source.lines[9].ignore.should.equal(false)
-    })
-
-    it('ignore hint accepts other text content', () => {
-      const sourceRaw = `
-      const a = 33
-
-      /* c8 ignore next -- reasoning why this is ignored */
-      const b = 99
-
-      /* c8 ignore start: reasoning here */
-      function ignoreMe() {
-        // ...
-      }
-      /* c8 ignore stop -- @preserve */
-
-      const c = a ? true /* c8 ignore next reasoning here */ : false
-
-      /* c8 ignore next 2 -- ignores next two lines */
-      const a = 33
-      const a = 99
-      `
-      const source = new CovSource(sourceRaw, 0)
-      source.lines[1].ignore.should.equal(false)
-      source.lines[2].ignore.should.equal(false)
-      source.lines[3].ignore.should.equal(true)
-      source.lines[4].ignore.should.equal(true)
-      source.lines[5].ignore.should.equal(false)
-      source.lines[6].ignore.should.equal(true)
-      source.lines[7].ignore.should.equal(true)
-      source.lines[8].ignore.should.equal(true)
-      source.lines[9].ignore.should.equal(true)
-      source.lines[10].ignore.should.equal(true)
-      source.lines[11].ignore.should.equal(false)
-      source.lines[12].ignore.should.equal(true)
-      source.lines[13].ignore.should.equal(false)
-      source.lines[14].ignore.should.equal(true)
-      source.lines[15].ignore.should.equal(true)
-      source.lines[16].ignore.should.equal(true)
-    })
-  })
+  }
 })


### PR DESCRIPTION
- Closes #215

Adds support for `/* v8 ignore ...` ignore hints. For backwards compatibility the old `/* c8 ignore ...` is still supported.

Test cases contain plenty of whitespace changes caused by indentation bump. I recommend to hide whitespaces on the diff.  