### PR TITLE
fix: ignore lines have to be dropped from coverage and not to be included as covered

### DIFF
--- a/lib/line.js
+++ b/lib/line.js
@@ -16,7 +16,8 @@ module.exports = class CovLine {
     this.count = 1
 
     // set by source.js during parsing, if /* c8 ignore next */ is found.
-    this.ignore = false
+    // also can be comment or empty line.
+    this.ignore = /^\s*\/{2}.+\s*$|^\s*$|^\s*\/\*.+\*\/\s*$/.test(lineStr)
   }
 
   toIstanbul () {

--- a/lib/source.js
+++ b/lib/source.js
@@ -27,7 +27,7 @@ module.exports = class CovSource {
       this.lines.push(line)
       position += lineStr.length
 
-      const ignoreToken = this._parseIgnore(lineStr)
+      const ignoreToken = this._parseIgnore(lineStr, ignoreAll)
       if (!ignoreToken) continue
 
       line.ignore = true
@@ -51,7 +51,7 @@ module.exports = class CovSource {
    * @param {string} lineStr
    * @return {{count?: number, start?: boolean, stop?: boolean}|undefined}
    */
-  _parseIgnore (lineStr) {
+  _parseIgnore (lineStr, ignoreAll) {
     const testIgnoreNextLines = lineStr.match(/^\W*\/\* [c|v]8 ignore next (?<count>[0-9]+)/)
     if (testIgnoreNextLines) {
       return { count: Number(testIgnoreNextLines.groups.count) }
@@ -72,6 +72,9 @@ module.exports = class CovSource {
       if (testIgnoreStartStop.groups.mode === 'start') return { start: true }
       if (testIgnoreStartStop.groups.mode === 'stop') return { stop: true }
     }
+
+    if (/^\s*\/\*.*(?<!\*\/)\s*$/.test(lineStr)) return { start: true }
+    if (ignoreAll && /^.*?\*\/\s*$/.test(lineStr)) return { stop: true }
   }
 
   // given a start column and end column in absolute offsets within

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -281,8 +281,11 @@ module.exports = class V8ToIstanbul {
       s: {}
     }
     source.lines.forEach((line, index) => {
+      if (line.ignore) {
+        return;
+      }
       statements.statementMap[`${index}`] = line.toIstanbul()
-      statements.s[`${index}`] = line.ignore ? 1 : line.count
+      statements.s[`${index}`] = line.count
     })
     return statements
   }

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -281,9 +281,7 @@ module.exports = class V8ToIstanbul {
       s: {}
     }
     source.lines.forEach((line, index) => {
-      if (line.ignore) {
-        return;
-      }
+      if (line.ignore) return
       statements.statementMap[`${index}`] = line.toIstanbul()
       statements.s[`${index}`] = line.count
     })

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -385,8 +385,6 @@ Object {
     "31": 1,
     "32": 1,
     "33": 1,
-    "34": 1,
-    "35": 1,
     "36": 1,
     "37": 1,
     "4": 1,
@@ -675,26 +673,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 34,
-      },
-    },
-    "34": Object {
-      "end": Object {
-        "column": 22,
-        "line": 35,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 35,
-      },
-    },
-    "35": Object {
-      "end": Object {
-        "column": 28,
-        "line": 36,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 36,
       },
     },
     "36": Object {

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -31,7 +31,7 @@ Object {
       1,
     ],
     "7": Array [
-      0,
+      1,
     ],
     "8": Array [
       1,
@@ -357,7 +357,6 @@ Object {
     },
   },
   "s": Object {
-    "0": 1,
     "1": 1,
     "10": 1,
     "11": 0,
@@ -365,46 +364,24 @@ Object {
     "13": 1,
     "14": 1,
     "15": 1,
-    "16": 1,
-    "17": 1,
     "18": 1,
     "19": 1,
-    "2": 1,
     "20": 1,
     "21": 1,
     "22": 1,
     "23": 1,
     "24": 1,
-    "25": 1,
     "26": 1,
-    "27": 1,
-    "28": 1,
     "29": 1,
-    "3": 1,
     "30": 1,
-    "31": 1,
     "32": 1,
     "33": 1,
     "36": 1,
     "37": 1,
     "4": 1,
-    "5": 1,
-    "6": 1,
     "7": 1,
-    "8": 1,
-    "9": 1,
   },
   "statementMap": Object {
-    "0": Object {
-      "end": Object {
-        "column": 26,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
     "1": Object {
       "end": Object {
         "column": 18,
@@ -475,26 +452,6 @@ Object {
         "line": 16,
       },
     },
-    "16": Object {
-      "end": Object {
-        "column": 0,
-        "line": 17,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 17,
-      },
-    },
-    "17": Object {
-      "end": Object {
-        "column": 28,
-        "line": 18,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 18,
-      },
-    },
     "18": Object {
       "end": Object {
         "column": 15,
@@ -513,16 +470,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 20,
-      },
-    },
-    "2": Object {
-      "end": Object {
-        "column": 0,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 3,
       },
     },
     "20": Object {
@@ -575,16 +522,6 @@ Object {
         "line": 25,
       },
     },
-    "25": Object {
-      "end": Object {
-        "column": 0,
-        "line": 26,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 26,
-      },
-    },
     "26": Object {
       "end": Object {
         "column": 3,
@@ -593,26 +530,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 27,
-      },
-    },
-    "27": Object {
-      "end": Object {
-        "column": 0,
-        "line": 28,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 28,
-      },
-    },
-    "28": Object {
-      "end": Object {
-        "column": 46,
-        "line": 29,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 29,
       },
     },
     "29": Object {
@@ -625,16 +542,6 @@ Object {
         "line": 30,
       },
     },
-    "3": Object {
-      "end": Object {
-        "column": 31,
-        "line": 4,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 4,
-      },
-    },
     "30": Object {
       "end": Object {
         "column": 10,
@@ -643,16 +550,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 31,
-      },
-    },
-    "31": Object {
-      "end": Object {
-        "column": 0,
-        "line": 32,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 32,
       },
     },
     "32": Object {
@@ -705,26 +602,6 @@ Object {
         "line": 5,
       },
     },
-    "5": Object {
-      "end": Object {
-        "column": 0,
-        "line": 6,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 6,
-      },
-    },
-    "6": Object {
-      "end": Object {
-        "column": 18,
-        "line": 7,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 7,
-      },
-    },
     "7": Object {
       "end": Object {
         "column": 31,
@@ -733,26 +610,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 8,
-      },
-    },
-    "8": Object {
-      "end": Object {
-        "column": 0,
-        "line": 9,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 9,
-      },
-    },
-    "9": Object {
-      "end": Object {
-        "column": 16,
-        "line": 10,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 10,
       },
     },
   },
@@ -776,13 +633,13 @@ Object {
       0,
     ],
     "4": Array [
-      0,
+      1,
     ],
     "5": Array [
       0,
     ],
     "6": Array [
-      2,
+      1,
     ],
     "7": Array [
       1,
@@ -1030,9 +887,9 @@ Object {
   "f": Object {
     "0": 0,
     "1": 1,
-    "2": 2,
+    "2": 1,
     "3": 0,
-    "4": 0,
+    "4": 1,
     "5": 1,
     "6": 1,
   },
@@ -1207,26 +1064,19 @@ Object {
     },
   },
   "s": Object {
-    "0": 1,
     "1": 1,
     "10": 1,
     "11": 1,
     "12": 1,
     "13": 1,
-    "14": 1,
     "15": 1,
-    "16": 1,
-    "17": 1,
     "18": 1,
     "19": 1,
     "2": 1,
     "20": 1,
     "21": 1,
     "22": 1,
-    "23": 1,
     "24": 1,
-    "25": 1,
-    "26": 1,
     "27": 1,
     "28": 1,
     "29": 1,
@@ -1236,8 +1086,6 @@ Object {
     "32": 1,
     "33": 0,
     "34": 0,
-    "35": 0,
-    "36": 1,
     "37": 0,
     "38": 1,
     "39": 1,
@@ -1247,26 +1095,13 @@ Object {
     "42": 1,
     "43": 1,
     "44": 1,
-    "45": 1,
     "46": 1,
     "47": 1,
     "5": 0,
-    "6": 0,
-    "7": 0,
     "8": 0,
     "9": 1,
   },
   "statementMap": Object {
-    "0": Object {
-      "end": Object {
-        "column": 30,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
     "1": Object {
       "end": Object {
         "column": 14,
@@ -1317,16 +1152,6 @@ Object {
         "line": 14,
       },
     },
-    "14": Object {
-      "end": Object {
-        "column": 0,
-        "line": 15,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 15,
-      },
-    },
     "15": Object {
       "end": Object {
         "column": 3,
@@ -1335,26 +1160,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 16,
-      },
-    },
-    "16": Object {
-      "end": Object {
-        "column": 0,
-        "line": 17,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 17,
-      },
-    },
-    "17": Object {
-      "end": Object {
-        "column": 41,
-        "line": 18,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 18,
       },
     },
     "18": Object {
@@ -1417,16 +1222,6 @@ Object {
         "line": 23,
       },
     },
-    "23": Object {
-      "end": Object {
-        "column": 0,
-        "line": 24,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 24,
-      },
-    },
     "24": Object {
       "end": Object {
         "column": 8,
@@ -1435,26 +1230,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 25,
-      },
-    },
-    "25": Object {
-      "end": Object {
-        "column": 0,
-        "line": 26,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 26,
-      },
-    },
-    "26": Object {
-      "end": Object {
-        "column": 48,
-        "line": 27,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 27,
       },
     },
     "27": Object {
@@ -1547,26 +1322,6 @@ Object {
         "line": 35,
       },
     },
-    "35": Object {
-      "end": Object {
-        "column": 0,
-        "line": 36,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 36,
-      },
-    },
-    "36": Object {
-      "end": Object {
-        "column": 42,
-        "line": 37,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 37,
-      },
-    },
     "37": Object {
       "end": Object {
         "column": 13,
@@ -1657,16 +1412,6 @@ Object {
         "line": 45,
       },
     },
-    "45": Object {
-      "end": Object {
-        "column": 0,
-        "line": 46,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 46,
-      },
-    },
     "46": Object {
       "end": Object {
         "column": 19,
@@ -1695,26 +1440,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 6,
-      },
-    },
-    "6": Object {
-      "end": Object {
-        "column": 0,
-        "line": 7,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 7,
-      },
-    },
-    "7": Object {
-      "end": Object {
-        "column": 31,
-        "line": 8,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 8,
       },
     },
     "8": Object {
@@ -2030,7 +1755,7 @@ Object {
       1,
     ],
     "5": Array [
-      0,
+      1,
     ],
     "6": Array [
       0,
@@ -2039,7 +1764,7 @@ Object {
       1,
     ],
     "8": Array [
-      0,
+      1,
     ],
   },
   "branchMap": Object {
@@ -2308,7 +2033,6 @@ Object {
     },
   },
   "s": Object {
-    "0": 0,
     "1": 1,
     "10": 1,
     "11": 1,
@@ -2316,41 +2040,20 @@ Object {
     "13": 1,
     "14": 0,
     "15": 0,
-    "16": 0,
-    "17": 0,
     "18": 1,
     "19": 1,
-    "2": 1,
     "20": 1,
     "21": 1,
     "22": 1,
     "23": 1,
     "24": 1,
-    "25": 1,
     "26": 1,
-    "27": 1,
-    "28": 0,
     "29": 1,
-    "3": 1,
     "30": 1,
     "4": 1,
-    "5": 1,
-    "6": 1,
     "7": 1,
-    "8": 1,
-    "9": 1,
   },
   "statementMap": Object {
-    "0": Object {
-      "end": Object {
-        "column": 26,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
     "1": Object {
       "end": Object {
         "column": 18,
@@ -2421,26 +2124,6 @@ Object {
         "line": 16,
       },
     },
-    "16": Object {
-      "end": Object {
-        "column": 0,
-        "line": 17,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 17,
-      },
-    },
-    "17": Object {
-      "end": Object {
-        "column": 28,
-        "line": 18,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 18,
-      },
-    },
     "18": Object {
       "end": Object {
         "column": 15,
@@ -2459,16 +2142,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 20,
-      },
-    },
-    "2": Object {
-      "end": Object {
-        "column": 0,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 3,
       },
     },
     "20": Object {
@@ -2521,16 +2194,6 @@ Object {
         "line": 25,
       },
     },
-    "25": Object {
-      "end": Object {
-        "column": 0,
-        "line": 26,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 26,
-      },
-    },
     "26": Object {
       "end": Object {
         "column": 3,
@@ -2541,26 +2204,6 @@ Object {
         "line": 27,
       },
     },
-    "27": Object {
-      "end": Object {
-        "column": 0,
-        "line": 28,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 28,
-      },
-    },
-    "28": Object {
-      "end": Object {
-        "column": 46,
-        "line": 29,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 29,
-      },
-    },
     "29": Object {
       "end": Object {
         "column": 15,
@@ -2569,16 +2212,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 30,
-      },
-    },
-    "3": Object {
-      "end": Object {
-        "column": 31,
-        "line": 4,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 4,
       },
     },
     "30": Object {
@@ -2601,26 +2234,6 @@ Object {
         "line": 5,
       },
     },
-    "5": Object {
-      "end": Object {
-        "column": 0,
-        "line": 6,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 6,
-      },
-    },
-    "6": Object {
-      "end": Object {
-        "column": 18,
-        "line": 7,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 7,
-      },
-    },
     "7": Object {
       "end": Object {
         "column": 31,
@@ -2629,26 +2242,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 8,
-      },
-    },
-    "8": Object {
-      "end": Object {
-        "column": 0,
-        "line": 9,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 9,
-      },
-    },
-    "9": Object {
-      "end": Object {
-        "column": 16,
-        "line": 10,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 10,
       },
     },
   },
@@ -2896,69 +2489,40 @@ Object {
     },
   },
   "s": Object {
-    "0": 1,
     "1": 1,
-    "10": 1,
     "11": 1,
     "12": 1,
     "13": 1,
     "14": 1,
     "15": 1,
-    "16": 1,
-    "17": 1,
     "18": 1,
-    "19": 1,
-    "2": 1,
-    "20": 1,
     "21": 1,
-    "22": 1,
-    "23": 1,
     "24": 1,
     "25": 0,
-    "26": 1,
-    "27": 1,
-    "28": 1,
     "29": 1,
-    "3": 1,
-    "30": 1,
-    "31": 1,
     "32": 1,
-    "33": 1,
-    "34": 1,
     "35": 1,
     "36": 0,
     "37": 0,
     "38": 1,
     "39": 1,
     "4": 1,
-    "40": 1,
-    "41": 1,
     "42": 1,
     "43": 0,
     "44": 0,
     "45": 0,
     "46": 0,
     "47": 1,
-    "48": 1,
-    "49": 1,
-    "5": 1,
-    "50": 1,
-    "51": 1,
-    "52": 1,
-    "53": 1,
     "54": 1,
     "55": 0,
     "56": 0,
     "57": 0,
     "58": 0,
     "59": 0,
-    "6": 1,
     "60": 0,
     "61": 0,
     "62": 0,
     "63": 1,
-    "64": 1,
-    "65": 1,
     "66": 1,
     "67": 0,
     "68": 0,
@@ -2967,30 +2531,13 @@ Object {
     "70": 0,
     "71": 0,
     "72": 1,
-    "73": 1,
-    "74": 1,
     "75": 1,
-    "76": 1,
-    "77": 1,
     "78": 1,
-    "79": 1,
     "8": 1,
-    "80": 1,
-    "81": 1,
     "82": 1,
     "9": 1,
   },
   "statementMap": Object {
-    "0": Object {
-      "end": Object {
-        "column": 21,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
     "1": Object {
       "end": Object {
         "column": 28,
@@ -2999,16 +2546,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 2,
-      },
-    },
-    "10": Object {
-      "end": Object {
-        "column": 53,
-        "line": 11,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 11,
       },
     },
     "11": Object {
@@ -3061,26 +2598,6 @@ Object {
         "line": 16,
       },
     },
-    "16": Object {
-      "end": Object {
-        "column": 0,
-        "line": 17,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 17,
-      },
-    },
-    "17": Object {
-      "end": Object {
-        "column": 33,
-        "line": 18,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 18,
-      },
-    },
     "18": Object {
       "end": Object {
         "column": 87,
@@ -3091,36 +2608,6 @@ Object {
         "line": 19,
       },
     },
-    "19": Object {
-      "end": Object {
-        "column": 0,
-        "line": 20,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 20,
-      },
-    },
-    "2": Object {
-      "end": Object {
-        "column": 0,
-        "line": 3,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 3,
-      },
-    },
-    "20": Object {
-      "end": Object {
-        "column": 31,
-        "line": 21,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 21,
-      },
-    },
     "21": Object {
       "end": Object {
         "column": 19,
@@ -3129,26 +2616,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 22,
-      },
-    },
-    "22": Object {
-      "end": Object {
-        "column": 0,
-        "line": 23,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 23,
-      },
-    },
-    "23": Object {
-      "end": Object {
-        "column": 38,
-        "line": 24,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 24,
       },
     },
     "24": Object {
@@ -3171,36 +2638,6 @@ Object {
         "line": 26,
       },
     },
-    "26": Object {
-      "end": Object {
-        "column": 0,
-        "line": 27,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 27,
-      },
-    },
-    "27": Object {
-      "end": Object {
-        "column": 0,
-        "line": 28,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 28,
-      },
-    },
-    "28": Object {
-      "end": Object {
-        "column": 52,
-        "line": 29,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 29,
-      },
-    },
     "29": Object {
       "end": Object {
         "column": 34,
@@ -3211,36 +2648,6 @@ Object {
         "line": 30,
       },
     },
-    "3": Object {
-      "end": Object {
-        "column": 25,
-        "line": 4,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 4,
-      },
-    },
-    "30": Object {
-      "end": Object {
-        "column": 0,
-        "line": 31,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 31,
-      },
-    },
-    "31": Object {
-      "end": Object {
-        "column": 28,
-        "line": 32,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 32,
-      },
-    },
     "32": Object {
       "end": Object {
         "column": 43,
@@ -3249,26 +2656,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 33,
-      },
-    },
-    "33": Object {
-      "end": Object {
-        "column": 0,
-        "line": 34,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 34,
-      },
-    },
-    "34": Object {
-      "end": Object {
-        "column": 47,
-        "line": 35,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 35,
       },
     },
     "35": Object {
@@ -3331,26 +2718,6 @@ Object {
         "line": 5,
       },
     },
-    "40": Object {
-      "end": Object {
-        "column": 0,
-        "line": 41,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 41,
-      },
-    },
-    "41": Object {
-      "end": Object {
-        "column": 33,
-        "line": 42,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 42,
-      },
-    },
     "42": Object {
       "end": Object {
         "column": 45,
@@ -3409,76 +2776,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 48,
-      },
-    },
-    "48": Object {
-      "end": Object {
-        "column": 0,
-        "line": 49,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 49,
-      },
-    },
-    "49": Object {
-      "end": Object {
-        "column": 35,
-        "line": 50,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 50,
-      },
-    },
-    "5": Object {
-      "end": Object {
-        "column": 0,
-        "line": 6,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 6,
-      },
-    },
-    "50": Object {
-      "end": Object {
-        "column": 47,
-        "line": 51,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 51,
-      },
-    },
-    "51": Object {
-      "end": Object {
-        "column": 56,
-        "line": 52,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 52,
-      },
-    },
-    "52": Object {
-      "end": Object {
-        "column": 50,
-        "line": 53,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 53,
-      },
-    },
-    "53": Object {
-      "end": Object {
-        "column": 36,
-        "line": 54,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 54,
       },
     },
     "54": Object {
@@ -3541,16 +2838,6 @@ Object {
         "line": 60,
       },
     },
-    "6": Object {
-      "end": Object {
-        "column": 33,
-        "line": 7,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 7,
-      },
-    },
     "60": Object {
       "end": Object {
         "column": 76,
@@ -3589,26 +2876,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 64,
-      },
-    },
-    "64": Object {
-      "end": Object {
-        "column": 0,
-        "line": 65,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 65,
-      },
-    },
-    "65": Object {
-      "end": Object {
-        "column": 73,
-        "line": 66,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 66,
       },
     },
     "66": Object {
@@ -3691,26 +2958,6 @@ Object {
         "line": 73,
       },
     },
-    "73": Object {
-      "end": Object {
-        "column": 0,
-        "line": 74,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 74,
-      },
-    },
-    "74": Object {
-      "end": Object {
-        "column": 41,
-        "line": 75,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 75,
-      },
-    },
     "75": Object {
       "end": Object {
         "column": 120,
@@ -3719,26 +2966,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 76,
-      },
-    },
-    "76": Object {
-      "end": Object {
-        "column": 0,
-        "line": 77,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 77,
-      },
-    },
-    "77": Object {
-      "end": Object {
-        "column": 28,
-        "line": 78,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 78,
       },
     },
     "78": Object {
@@ -3751,16 +2978,6 @@ Object {
         "line": 79,
       },
     },
-    "79": Object {
-      "end": Object {
-        "column": 0,
-        "line": 80,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 80,
-      },
-    },
     "8": Object {
       "end": Object {
         "column": 46,
@@ -3769,26 +2986,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 9,
-      },
-    },
-    "80": Object {
-      "end": Object {
-        "column": 0,
-        "line": 81,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 81,
-      },
-    },
-    "81": Object {
-      "end": Object {
-        "column": 41,
-        "line": 82,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 82,
       },
     },
     "82": Object {

--- a/test/source.js
+++ b/test/source.js
@@ -96,6 +96,24 @@ describe('Source', () => {
         source.lines[3].ignore.should.equal(true)
       })
 
+      it('ignores a multiple javascript comment', () => {
+        const sourceRaw = `
+        /*  mutltiple commment
+         *  mutltiple commment
+         *  mutltiple commment
+         */
+        const a = 33
+        const a = 99
+        `
+        const source = new CovSource(sourceRaw, 0)
+        source.lines[1].ignore.should.equal(true)
+        source.lines[2].ignore.should.equal(true)
+        source.lines[3].ignore.should.equal(true)
+        source.lines[4].ignore.should.equal(true)
+        source.lines[5].ignore.should.equal(false)
+        source.lines[6].ignore.should.equal(false)
+      })
+
       it(`ignores a line that contains /* ${prefix} ignore next */`, () => {
         const sourceRaw = `
         const a = foo ? true /* ${prefix} ignore next */ : false
@@ -115,7 +133,7 @@ describe('Source', () => {
         /* ${prefix} ignore stop */
 
         function doNotIgnoreMe() {
-          // ...
+          return a + b
         }
         `
         const source = new CovSource(sourceRaw, 0)
@@ -124,7 +142,7 @@ describe('Source', () => {
         source.lines[3].ignore.should.equal(true)
         source.lines[4].ignore.should.equal(true)
         source.lines[5].ignore.should.equal(true)
-        source.lines[6].ignore.should.equal(false)
+        source.lines[6].ignore.should.equal(true)
         source.lines[7].ignore.should.equal(false)
         source.lines[8].ignore.should.equal(false)
         source.lines[9].ignore.should.equal(false)
@@ -151,18 +169,18 @@ describe('Source', () => {
         `
         const source = new CovSource(sourceRaw, 0)
         source.lines[1].ignore.should.equal(false)
-        source.lines[2].ignore.should.equal(false)
+        source.lines[2].ignore.should.equal(true)
         source.lines[3].ignore.should.equal(true)
         source.lines[4].ignore.should.equal(true)
-        source.lines[5].ignore.should.equal(false)
+        source.lines[5].ignore.should.equal(true)
         source.lines[6].ignore.should.equal(true)
         source.lines[7].ignore.should.equal(true)
         source.lines[8].ignore.should.equal(true)
         source.lines[9].ignore.should.equal(true)
         source.lines[10].ignore.should.equal(true)
-        source.lines[11].ignore.should.equal(false)
+        source.lines[11].ignore.should.equal(true)
         source.lines[12].ignore.should.equal(true)
-        source.lines[13].ignore.should.equal(false)
+        source.lines[13].ignore.should.equal(true)
         source.lines[14].ignore.should.equal(true)
         source.lines[15].ignore.should.equal(true)
         source.lines[16].ignore.should.equal(true)

--- a/test/utils/run-fixture.js
+++ b/test/utils/run-fixture.js
@@ -23,7 +23,7 @@ module.exports = async (fixture) => {
   coverageIstanbul = coverageIstanbul[Object.keys(coverageIstanbul)[0]]
 
   describe(fixture.describe, () => {
-    it('matches snapshot', () => {
+    it(`matches snapshot ${fixture.describe}`, () => {
       delete coverageIstanbul.path
       t.matchSnapshot(coverageIstanbul, `must match ${fixture.describe} snapshot`)
     })

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -288,7 +288,6 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       0: 0,
       1: 0,
       2: 0,
-      3: 0,
       4: 0,
       5: 0,
       6: 0

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -163,7 +163,7 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       const coverageMap = v8ToIstanbul.toIstanbul()
       const { s } = coverageMap[filename]
 
-      assert.deepStrictEqual(s, { 0: 1, 1: 1, 2: 1, 3: 1 })
+      assert.deepStrictEqual(s, {})
     })
   })
 


### PR DESCRIPTION
Html coverage report base on statementMap and s then if line doesn't exists will be marked 'neutral' by default.

It will be repeat behavior "istanbul ignore"