### PR TITLE
feat: exclude lines that are missing from source maps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,6 @@ declare class V8ToIstanbul {
   toIstanbul(): CoverageMapData
 }
 
-declare function v8ToIstanbul(scriptPath: string, wrapperLength?: number, sources?: Sources, excludePath?: (path: string) => boolean): V8ToIstanbul
+declare function v8ToIstanbul(scriptPath: string, wrapperLength?: number, sources?: Sources, excludePath?: (path: string) => boolean, excludeEmptyLines?: boolean): V8ToIstanbul
 
 export = v8ToIstanbul

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const V8ToIstanbul = require('./lib/v8-to-istanbul')
 
-module.exports = function (path, wrapperLength, sources, excludePath) {
-  return new V8ToIstanbul(path, wrapperLength, sources, excludePath)
+module.exports = function (path, wrapperLength, sources, excludePath, excludeEmptyLines) {
+  return new V8ToIstanbul(path, wrapperLength, sources, excludePath, excludeEmptyLines)
 }

--- a/lib/source.js
+++ b/lib/source.js
@@ -1,23 +1,31 @@
 const CovLine = require('./line')
 const { sliceRange } = require('./range')
-const { originalPositionFor, generatedPositionFor, GREATEST_LOWER_BOUND, LEAST_UPPER_BOUND } = require('@jridgewell/trace-mapping')
+const { originalPositionFor, generatedPositionFor, eachMapping, GREATEST_LOWER_BOUND, LEAST_UPPER_BOUND } = require('@jridgewell/trace-mapping')
 
 module.exports = class CovSource {
-  constructor (sourceRaw, wrapperLength) {
+  constructor (sourceRaw, wrapperLength, traceMap) {
     sourceRaw = sourceRaw ? sourceRaw.trimEnd() : ''
     this.lines = []
     this.eof = sourceRaw.length
     this.shebangLength = getShebangLength(sourceRaw)
     this.wrapperLength = wrapperLength - this.shebangLength
-    this._buildLines(sourceRaw)
+    this._buildLines(sourceRaw, traceMap)
   }
 
-  _buildLines (source) {
+  _buildLines (source, traceMap) {
     let position = 0
     let ignoreCount = 0
     let ignoreAll = false
+    const linesToCover = traceMap && this._parseLinesToCover(traceMap)
+
     for (const [i, lineStr] of source.split(/(?<=\r?\n)/u).entries()) {
-      const line = new CovLine(i + 1, position, lineStr)
+      const lineNumber = i + 1
+      const line = new CovLine(lineNumber, position, lineStr)
+
+      if (linesToCover && !linesToCover.has(lineNumber)) {
+        line.ignore = true
+      }
+
       if (ignoreCount > 0) {
         line.ignore = true
         ignoreCount--
@@ -124,6 +132,18 @@ module.exports = class CovSource {
     line = Math.max(line, 1)
     if (this.lines[line - 1] === undefined) return this.eof
     return Math.min(this.lines[line - 1].startCol + relCol, this.lines[line - 1].endCol)
+  }
+
+  _parseLinesToCover (traceMap) {
+    const linesToCover = new Set()
+
+    eachMapping(traceMap, (mapping) => {
+      if (mapping.originalLine !== null) {
+        linesToCover.add(mapping.originalLine)
+      }
+    })
+
+    return linesToCover
   }
 }
 

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -25,12 +25,13 @@ const isNode8 = /^v8\./.test(process.version)
 const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
 
 module.exports = class V8ToIstanbul {
-  constructor (scriptPath, wrapperLength, sources, excludePath) {
+  constructor (scriptPath, wrapperLength, sources, excludePath, excludeEmptyLines) {
     assert(typeof scriptPath === 'string', 'scriptPath must be a string')
     assert(!isNode8, 'This module does not support node 8 or lower, please upgrade to node 10')
     this.path = parsePath(scriptPath)
     this.wrapperLength = wrapperLength === undefined ? cjsWrapperLength : wrapperLength
     this.excludePath = excludePath || (() => false)
+    this.excludeEmptyLines = excludeEmptyLines === true
     this.sources = sources || {}
     this.generatedLines = []
     this.branches = {}
@@ -58,8 +59,8 @@ module.exports = class V8ToIstanbul {
         if (!this.sourceMap.sourcesContent) {
           this.sourceMap.sourcesContent = await this.sourcesContentFromSources()
         }
-        this.covSources = this.sourceMap.sourcesContent.map((rawSource, i) => ({ source: new CovSource(rawSource, this.wrapperLength), path: this.sourceMap.sources[i] }))
-        this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+        this.covSources = this.sourceMap.sourcesContent.map((rawSource, i) => ({ source: new CovSource(rawSource, this.wrapperLength, this.excludeEmptyLines ? this.sourceMap : null), path: this.sourceMap.sources[i] }))
+        this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength, this.excludeEmptyLines ? this.sourceMap : null)
       } else {
         const candidatePath = this.rawSourceMap.sourcemap.sources.length >= 1 ? this.rawSourceMap.sourcemap.sources[0] : this.rawSourceMap.sourcemap.file
         this.path = this._resolveSource(this.rawSourceMap, candidatePath || this.path)
@@ -82,8 +83,8 @@ module.exports = class V8ToIstanbul {
           // We fallback to reading the original source from disk.
           originalRawSource = await readFile(this.path, 'utf8')
         }
-        this.covSources = [{ source: new CovSource(originalRawSource, this.wrapperLength), path: this.path }]
-        this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
+        this.covSources = [{ source: new CovSource(originalRawSource, this.wrapperLength, this.excludeEmptyLines ? this.sourceMap : null), path: this.path }]
+        this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength, this.excludeEmptyLines ? this.sourceMap : null)
       }
     } else {
       this.covSources = [{ source: new CovSource(rawSource, this.wrapperLength), path: this.path }]

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -281,8 +281,10 @@ module.exports = class V8ToIstanbul {
       s: {}
     }
     source.lines.forEach((line, index) => {
-      statements.statementMap[`${index}`] = line.toIstanbul()
-      statements.s[`${index}`] = line.ignore ? 1 : line.count
+      if (!line.ignore) {
+        statements.statementMap[`${index}`] = line.toIstanbul()
+        statements.s[`${index}`] = line.count
+      }
     })
     return statements
   }

--- a/tap-snapshots/test/v8-to-istanbul.js.test.cjs
+++ b/tap-snapshots/test/v8-to-istanbul.js.test.cjs
@@ -385,8 +385,6 @@ Object {
     "31": 1,
     "32": 1,
     "33": 1,
-    "34": 1,
-    "35": 1,
     "36": 1,
     "37": 1,
     "4": 1,
@@ -675,26 +673,6 @@ Object {
       "start": Object {
         "column": 0,
         "line": 34,
-      },
-    },
-    "34": Object {
-      "end": Object {
-        "column": 22,
-        "line": 35,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 35,
-      },
-    },
-    "35": Object {
-      "end": Object {
-        "column": 28,
-        "line": 36,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 36,
       },
     },
     "36": Object {

--- a/test/fixtures/scripts/ignored.lines.js
+++ b/test/fixtures/scripts/ignored.lines.js
@@ -1,4 +1,13 @@
-/* c8 ignore next 3 */
 function sum(a, b) {
+  if(a === 2 && b === 2) {
+    return 4;
+  }
+
+  /* v8 ignore start */ // Line 6
+  if (a === '10') {
+    return add(a, b)
+  }
+  /* v8 ignore stop */ // Line 10
+
   return a + b;
 };

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -140,7 +140,7 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       Object.keys(v8ToIstanbul.toIstanbul()).should.eql(['/src/index.ts', '/src/utils.ts'].map(path.normalize))
     })
 
-    it('ignore hint marks statements of uncovered file as covered', async () => {
+    it('ignore hint marks statements of uncovered file as excluded', async () => {
       const filename = require.resolve('./fixtures/scripts/ignored.lines.js')
       const source = readFileSync(filename, 'utf-8')
       const v8ToIstanbul = new V8ToIstanbul(pathToFileURL(filename).href)
@@ -163,7 +163,19 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       const coverageMap = v8ToIstanbul.toIstanbul()
       const { s } = coverageMap[filename]
 
-      assert.deepStrictEqual(s, { 0: 1, 1: 1, 2: 1, 3: 1 })
+      assert.equal(s[0], 0)
+      assert.equal(s[1], 0)
+      assert.equal(s[2], 0)
+      assert.equal(s[3], 0)
+      assert.equal(s[4], 0)
+      assert.equal(s[5], undefined) // Line 6
+      assert.equal(s[6], undefined)
+      assert.equal(s[7], undefined)
+      assert.equal(s[8], undefined)
+      assert.equal(s[9], undefined) // Line 10
+      assert.equal(s[10], 0)
+      assert.equal(s[11], 0)
+      assert.equal(s[12], 0)
     })
   })
 


### PR DESCRIPTION
- Closes https://github.com/istanbuljs/v8-to-istanbul/issues/238
- Supersedes and closes https://github.com/istanbuljs/v8-to-istanbul/pull/212
- Supersedes and closes https://github.com/istanbuljs/v8-to-istanbul/pull/242

### `feat: exclude lines that are missing from source maps`

- When source maps are available, use `@jridgewell/trace-mapping` to figure out which lines contain runtime code. If a line is not present in source maps, consider it as empty line. This will exclude Typescript typings, comments, empty lines and any other special syntax that transpiled languages exclude from source maps.
- ~Should this be considered as breaking change or be a configurable option?~ ⚠️ 
  - This is now opt-in and configurable via `excludeEmptyLines` argument. No breaking changes. 

Examples:
 - Vitest
   - <img width="480px" src="https://github.com/istanbuljs/v8-to-istanbul/assets/14806298/fcd3c7bf-8ffe-4f5b-bd41-5929f3c070b5" />
   - <img width="480px" src="https://github.com/istanbuljs/v8-to-istanbul/assets/14806298/1efd70bc-cfb1-45a1-93f3-f00020ad2954" />

 - Jest
   - <img width="480px" src="https://github.com/istanbuljs/v8-to-istanbul/assets/14806298/997b8fb8-1b42-4085-af67-b3fbd32e84df">
 - Playwright
   - <img width="480px" src="https://github.com/istanbuljs/v8-to-istanbul/assets/14806298/e039c0fd-4215-4789-a6b9-25312a1701df" />

 - c8, test code transpiled with tsc. (`tsconfig.json`'s `removeComments` was disabled when taking the picture)
   - <img width="480px" src="https://github.com/istanbuljs/v8-to-istanbul/assets/14806298/dd0db501-7887-48df-9726-1174e3fb7c8f" />


### `fix: ignore hint to exclude lines`

- `/* v8 ignore ... */` should exclude the lines from coverage, not mark them as covered. 
  - <br /> <img width="480px" src="https://github.com/istanbuljs/v8-to-istanbul/assets/14806298/a0773c28-9190-4e3c-8f5c-c214d19ff635" />

