### PR TITLE
fix: flatten sectioned source maps with AnyMap

### DIFF
--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -16,7 +16,7 @@ try {
 } catch (_err) {
   // most likely we're on an older version of Node.js.
 }
-const { TraceMap } = require('@jridgewell/trace-mapping')
+const { AnyMap } = require('@jridgewell/trace-mapping')
 const isOlderNode10 = /^v10\.(([0-9]\.)|(1[0-5]\.))/u.test(process.version)
 const isNode8 = /^v8\./.test(process.version)
 
@@ -53,17 +53,21 @@ module.exports = class V8ToIstanbul {
       convertSourceMap.fromSource(rawSource) || convertSourceMap.fromMapFileSource(rawSource, this._readFileFromDir.bind(this))
 
     if (this.rawSourceMap) {
-      if (this.rawSourceMap.sourcemap.sources.length > 1) {
-        this.sourceMap = new TraceMap(this.rawSourceMap.sourcemap)
+      this.sourceMap = new AnyMap(this.rawSourceMap.sourcemap)
+      if (this.sourceMap.sources.length > 1) {
         if (!this.sourceMap.sourcesContent) {
           this.sourceMap.sourcesContent = await this.sourcesContentFromSources()
+        } else if (this.sourceMap.sourcesContent.some(content => content == null)) {
+          const loaded = await this.sourcesContentFromSources()
+          this.sourceMap.sourcesContent = this.sourceMap.sourcesContent.map((content, i) => {
+            return content == null ? loaded[i] : content
+          })
         }
         this.covSources = this.sourceMap.sourcesContent.map((rawSource, i) => ({ source: new CovSource(rawSource, this.wrapperLength), path: this.sourceMap.sources[i] }))
         this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
       } else {
-        const candidatePath = this.rawSourceMap.sourcemap.sources.length >= 1 ? this.rawSourceMap.sourcemap.sources[0] : this.rawSourceMap.sourcemap.file
+        const candidatePath = this.sourceMap.sources.length >= 1 ? this.sourceMap.sources[0] : this.rawSourceMap.sourcemap.file
         this.path = this._resolveSource(this.rawSourceMap, candidatePath || this.path)
-        this.sourceMap = new TraceMap(this.rawSourceMap.sourcemap)
 
         let originalRawSource
         if (this.sources.sourceMap && this.sources.sourceMap.sourcemap && this.sources.sourceMap.sourcemap.sourcesContent && this.sources.sourceMap.sourcemap.sourcesContent.length === 1) {
@@ -252,7 +256,7 @@ module.exports = class V8ToIstanbul {
     // TODO: could we move the resolving logic for 1:1 source maps to the final
     // step as well? currently this breaks some tests in c8.
     let resolvedPath = path
-    if (this.rawSourceMap && this.rawSourceMap.sourcemap.sources.length > 1) {
+    if (this.rawSourceMap && this.sourceMap.sources.length > 1) {
       resolvedPath = this._resolveSource(this.rawSourceMap, path)
     }
 

--- a/test/fixtures/scripts/sectioned-sourcemap.js
+++ b/test/fixtures/scripts/sectioned-sourcemap.js
@@ -1,0 +1,3 @@
+const a = 1
+const b = 2
+//# sourceMappingURL=sectioned-sourcemap.js.map

--- a/test/fixtures/scripts/sectioned-sourcemap.js.map
+++ b/test/fixtures/scripts/sectioned-sourcemap.js.map
@@ -1,0 +1,26 @@
+{
+  "version": 3,
+  "file": "sectioned-sourcemap.js",
+  "sections": [
+    {
+      "offset": { "line": 0, "column": 0 },
+      "map": {
+        "version": 3,
+        "sources": ["sectioned-a.js"],
+        "sourcesContent": ["const a = 1\n"],
+        "names": [],
+        "mappings": "AAAA"
+      }
+    },
+    {
+      "offset": { "line": 1, "column": 0 },
+      "map": {
+        "version": 3,
+        "sources": ["sectioned-b.js"],
+        "sourcesContent": ["const b = 2\n"],
+        "names": [],
+        "mappings": "AAAA"
+      }
+    }
+  ]
+}

--- a/test/v8-to-istanbul.js
+++ b/test/v8-to-istanbul.js
@@ -203,6 +203,27 @@ ${'//'}${'#'} sourceMappingURL=data:application/json;base64,${base64Sourcemap}
       v8ToIstanbul.covSources.length.should.equal(3)
       Object.keys(v8ToIstanbul.toIstanbul()).should.eql(['/webpack/bootstrap', '/src/index.ts', '/src/utils.ts'].map(path.normalize))
     })
+
+    it('should handle sectioned index source maps', async () => {
+      const v8ToIstanbul = new V8ToIstanbul(
+        pathToFileURL(require.resolve('./fixtures/scripts/sectioned-sourcemap.js')).href,
+        0
+      )
+      await v8ToIstanbul.load()
+
+      v8ToIstanbul.covSources.length.should.equal(2)
+      v8ToIstanbul.applyCoverage([{
+        functionName: 'fake',
+        ranges: [{
+          startOffset: 0,
+          endOffset: 1
+        }]
+      }])
+      Object.keys(v8ToIstanbul.toIstanbul()).map(file => path.basename(file)).sort().should.eql([
+        'sectioned-a.js',
+        'sectioned-b.js'
+      ])
+    })
   })
 
   it('test no sourcemap content', async () => {


### PR DESCRIPTION
## Summary

Turbopack emits [ECMA-426 index / sectioned source maps](https://tc39.es/ecma426/#sec-index-source-map) (`sections[]`, no top-level `mappings` or `sources`). `TraceMap` throws on those maps, so `v8-to-istanbul` cannot remap coverage for Turbopack output.

`AnyMap` (alias of `FlattenMap` in `@jridgewell/trace-mapping`) accepts either a regular or sectioned map and returns a `TraceMap`. This PR builds that flattened map **once** before the existing 1:1 / 1:many `covSources` fork, then branches on flattened `this.sourceMap.sources.length` (index maps have empty/missing top-level `sources`). After flatten, `sourcesContent` may contain `null` slots; those are filled from disk like the existing load path.

c8 depends on this package, so it inherits the fix.

Related: [jridgewell/sourcemaps#56](https://github.com/jridgewell/sourcemaps/pull/56) (README note that Turbopack emits sectioned maps).

## Test plan

- [x] `npm test` (tap + standard)
- [x] New fixture `test/fixtures/scripts/sectioned-sourcemap.js` + `.map` (index map with `sections[]`, no top-level `sources`)
- [x] Existing 1:1 / 1:many / empty-sources / `sourcesContent: null` cases still pass

Made with [Cursor](https://cursor.com)